### PR TITLE
initramfs handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [> 3.1.11.531910] Q4 2021
+- unbundle initramfs from kernel to speed up build times from sstate cache
+  (before the kernel and modules got build every time when building with
+  sstate cache)
+- add ics-dm-os-initramfs to sstate cache
+
 ## [> 3.1.11.1102] Q4 2021
 - enrollment: install new enrollment-patch-config-toml@.service
 

--- a/conf/distro/include/ics-dm-os-distro.conf
+++ b/conf/distro/include/ics-dm-os-distro.conf
@@ -40,10 +40,8 @@ IMAGE_ROOTFS_MAXSIZE = "524288"
 IMAGE_OVERHEAD_FACTOR = "1.1"
 
 # initramfs
-INITRAMFS_FSTYPES = "cpio.gz"
-INITRAMFS_IMAGE = "ics-dm-os-initramfs"
-INITRAMFS_IMAGE_NAME = "${DISTRO_NAME}_${DISTRO_VERSION}_${MACHINE}-initramfs.rootfs"
-INITRAMFS_IMAGE_BUNDLE = "1"
+ICS_DM_INITRAMFS_FSTYPE = "cpio.gz.u-boot"
+ICS_DM_INITRAMFS_IMAGE_NAME = "${DISTRO_NAME}_${DISTRO_VERSION}_${MACHINE}-initramfs"
 
 # enable curl-native with nghttp2 support for cargo-native(rust)
 #


### PR DESCRIPTION
- unbundle initramfs from kernel to speed up build times from sstate cache
  (before the kernel and modules got build every time when building with
  sstate cache)
- add ics-dm-os-initramfs to sstate cache