### PR TITLE
test-u-boot-scr: fix for rpi4 1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [> 3.1.13.14704614] Q1 2022
+- test-u-boot-scr: fixed setting `bootargs_append` for rpi4 v1.1, if the device
+  is completely flashed (u-boot env is erased) and then rebooted
+
 ## [> 3.1.13.14434558] Q1 2022
 - azure-iot-c-sdk: updated to `LTS_01_2022_Ref01`
 

--- a/recipes-bsp/u-boot/test-u-boot-scr.bb
+++ b/recipes-bsp/u-boot/test-u-boot-scr.bb
@@ -9,9 +9,9 @@ LIC_FILES_CHKSUM="\
 ICS_DM_BOOT_SCR_NAME = "test-boot.scr"
 
 # 0xC031111 is rpi4 1.1 (https://elinux.org/RPi_HardwareHistory)
-ICS_DM_BOOT_SCR_TEST_CMDS:raspberrypi4-64  = 'setenv bootcmd_pxe "dhcp; run set_bootfile; if pxe get; then pxe boot; fi"; '
-ICS_DM_BOOT_SCR_TEST_CMDS:raspberrypi4-64 .= 'setenv set_bootfile "if test \"0xC03111\" = \"${board_revision}\"; then setenv bootfile /custom/; setenv bootargs_append sdhci.debug_quirks2=4; saveenv; fi"; '
-ICS_DM_BOOT_SCR_TEST_CMDS:raspberrypi4-64 .= 'rstinfo; if test "${rstinfo}" = "POR"; then echo "Power-on detected; going to run PXE boot..."; run bootcmd_pxe; fi'
+ICS_DM_BOOT_SCR_TEST_CMDS:raspberrypi4-64  = 'setenv bootcmd_pxe "dhcp; run fix_rpi4_1_1; if pxe get; then pxe boot; fi"; '
+ICS_DM_BOOT_SCR_TEST_CMDS:raspberrypi4-64 .= 'setenv fix_rpi4_1_1 "if test \"0xC03111\" = \"${board_revision}\"; then setenv bootfile /custom/; setenv bootargs_append sdhci.debug_quirks2=4; saveenv; fi"; '
+ICS_DM_BOOT_SCR_TEST_CMDS:raspberrypi4-64 .= 'run fix_rpi4_1_1;rstinfo; if test "${rstinfo}" = "POR"; then echo "Power-on detected; going to run PXE boot..."; run bootcmd_pxe; fi'
 
 ICS_DM_BOOT_SCR_TEST_CMDS      = 'rstinfo; if test "${rstinfo}" = "POR"; then echo "Power-on detected; going to run PXE boot..."; run bootcmd_pxe; fi'
 inherit deploy nopackages u-boot-scr


### PR DESCRIPTION
test-u-boot-scr: fixed setting 'bootargs_append' for rpi4 v1.1, if the device
is completely flashed (u-boot env is erased) and then rebooted