### PR TITLE
dunfell 3.1.16 + enrollment update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [dunfell-1.2.0] Q2 2022
+- kas:
+  - meta-openembedded: updated to latest HEAD of dunfell
+  - meta-swupdate: updated to latest HEAD of dunfell
+  - poky: updated to 3.1.16
+  - meta-virtualization: updated to latest HEAD of dunfell
+- enrollment: updated to 0.8.0 (allows setting `DEVICE_ID` or
+  `DEVICE_ID_PREFIX` via environment file, e.g. via inject)
+
 ## [dunfell-1.1.0] Q2 2022
 - add user consent handling for iot-hub-device-update
 - demo-portal-module: version bump to 0.4.1
@@ -30,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [> 3.1.15.31043252] Q2 2022
 - enable, configure hardware watchdog for raspberrypi platform
-  
+
 ## [> 3.1.15.26343127] Q2 2022
 - iotedge: version bump to 1.2.9
 

--- a/kas/distro/ics-dm-os.yaml
+++ b/kas/distro/ics-dm-os.yaml
@@ -9,7 +9,7 @@ repos:
   meta-ics-dm:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    refspec: 86b864a4d8c28185a4a464583fb86f73aa22847a
+    refspec: 8ff12bfffcf0840d5518788a53d88d708ad3aae0
     layers:
       meta-filesystems:
       meta-networking:
@@ -20,7 +20,7 @@ repos:
     refspec: d4384db8c3f0aa01732627f92fc3d446359bf743
   ext/meta-swupdate:
     url: "https://github.com/sbabic/meta-swupdate.git"
-    refspec: 2e08de8582aa18871657ea8283ea35a050927d4f
+    refspec: 789109dae6e45aa0e7687dfbc6ee61fa9aace8d4
 
 distro: ics-dm-os
 
@@ -33,13 +33,13 @@ env:
   # build number which is reflected in DISTRO_VERSION
   ICS_DM_BUILD_NUMBER: "0"
   # changelog version and repo uri of meta-ics-dm
-  META_ICS_DM_VERSION: "META_ICS_DM_VERSION_NOT_SET" 
-  META_ICS_DM_GIT_REPO: "META_ICS_DM_GIT_REPO_NOT_SET" 
+  META_ICS_DM_VERSION: "META_ICS_DM_VERSION_NOT_SET"
+  META_ICS_DM_GIT_REPO: "META_ICS_DM_GIT_REPO_NOT_SET"
   # changelog version, revision, branch and repo uri of ics-dm-os
-  ICS_DM_OS_VERSION: "ICS_DM_OS_VERSION_NOT_SET" 
+  ICS_DM_OS_VERSION: "ICS_DM_OS_VERSION_NOT_SET"
   ICS_DM_OS_GIT_SHA: "ICS_DM_OS_GIT_SHA_NOT_SET"
   ICS_DM_OS_GIT_BRANCH: "ICS_DM_OS_GIT_BRANCH_NOT_SET"
-  ICS_DM_OS_GIT_REPO: "ICS_DM_OS_GIT_REPO_NOT_SET" 
+  ICS_DM_OS_GIT_REPO: "ICS_DM_OS_GIT_REPO_NOT_SET"
 
   # partition configuration
   ICS_DM_PART_SIZE_BOOT: "40960"

--- a/kas/distro/poky.yaml
+++ b/kas/distro/poky.yaml
@@ -8,7 +8,7 @@ distro: poky
 repos:
   ext/poky:
     url: "https://git.yoctoproject.org/git/poky"
-    refspec: yocto-3.1.15
+    refspec: yocto-3.1.16
     layers:
       meta:
       meta-poky:

--- a/kas/feature/iotedge.yaml
+++ b/kas/feature/iotedge.yaml
@@ -6,7 +6,7 @@ header:
 repos:
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/git/meta-virtualization"
-    refspec: c5f61e547b90aa8058cf816f00902afed9c96f72
+    refspec: f6b88c1d2f515ffac90457c0d649d6c805fff736
 
 local_conf_header:
   meta-ics-dm_feature_iotedge: |

--- a/recipes-ics-dm/enrollment/enrollment_git.bb
+++ b/recipes-ics-dm/enrollment/enrollment_git.bb
@@ -6,7 +6,7 @@ LIC_FILES_CHKSUM="\
 "
 
 # TODO change to https uri when public
-REPO_URI = "git://git@github.com/ICS-DeviceManagement/enrollment.git;protocol=ssh;branch=main;tag=0.7.2;"
+REPO_URI = "git://git@github.com/ICS-DeviceManagement/enrollment.git;protocol=ssh;branch=main;tag=0.8.0;"
 SRC_URI = "${REPO_URI}"
 
 S = "${WORKDIR}/git"


### PR DESCRIPTION
- kas:
  - meta-openembedded: updated to latest HEAD of dunfell
  - meta-swupdate: updated to latest HEAD of dunfell
  - poky: updated to 3.1.16
  - meta-virtualization: updated to latest HEAD of dunfell
- enrollment: updated to 0.8.0 (allows setting 'DEVICE_ID' or
  'DEVICE_ID_PREFIX' via environment file, e.g. via inject)

BLOCKED by https://github.com/ICS-DeviceManagement/enrollment/pull/20