### PR TITLE
updates + readme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [dunfell-1.3.5] Q2 2022
+ - poky: update to 3.1.17
+ - meta-openembedded, meta-swupdate, meta-phytec, meta-freescale: update to latest dunfell head
+ - Readme: added `scp` usage for new openssh clients (>=9.0)
+
 ## [dunfell-1.3.4] Q2 2022
 - make the hardware watchdog configuration specific for the raspberrypi platform, because the deadline
   depends on the hardware capabilities

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This yocto meta layer provides the poky based ICS_DeviceManagement distribution 
     - `iot-hub-device-update` is provisioned as module identity via `iot-identity-service`
     - first boot script `/usr/bin/ics_dm_first_boot.sh` which is executed at first boot of the device; it can be adapted via `meta-ics-dm/recipes-core/systemd/systemd/ics_dm_first_boot.sh`
     - factory reset via `u-boot` environment variable `factory-reset`
-      - **note**: This feature provides a limited level of data privacy. Please see section [Factory Reset](#factory-reset), below. 
+      - **note**: This feature provides a limited level of data privacy. Please see section [Factory Reset](#factory-reset), below.
 
 ### `DISTRO_FEATURES`
 `ics-dm-os` depends on [poky](https://www.yoctoproject.org/software-item/poky/).
@@ -193,6 +193,12 @@ In the next step, the bmap file and the wic image file have to be transferred, b
 scp ics-dm-os-*.wic.bmap ics-dm@<target-ip>:wic-image.bmap
 scp ics-dm-os-*.wic.xz ics-dm@<target-ip>:wic-image.fifo.xz
 ```
+On systems with new openssh clients >= 9.0 you have to use the legacy option when using `scp`. (See [here](https://www.openssh.com/txt/release-9.0) for details.) :
+```sh
+scp -O ics-dm-os-*.wic.bmap ics-dm@<target-ip>:wic-image.bmap
+scp -O ics-dm-os-*.wic.xz ics-dm@<target-ip>:wic-image.fifo.xz
+```
+
 The password for the *ics-dm* user used by the rootfs has to be used.
 The *ics-dm* user used by the initramfs is independent from the *ics-dm* user used by the rootfs.
 At build time, the configuration (ICS_DM_USER_PASSWORD) is applied for both. The passwords are identical.

--- a/kas/distro/ics-dm-os.yaml
+++ b/kas/distro/ics-dm-os.yaml
@@ -9,7 +9,7 @@ repos:
   meta-ics-dm:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    refspec: 8ff12bfffcf0840d5518788a53d88d708ad3aae0
+    refspec: deee226017877d51188e0a46f9e6b93c10ffbb34
     layers:
       meta-filesystems:
       meta-networking:
@@ -20,7 +20,7 @@ repos:
     refspec: d4384db8c3f0aa01732627f92fc3d446359bf743
   ext/meta-swupdate:
     url: "https://github.com/sbabic/meta-swupdate.git"
-    refspec: 789109dae6e45aa0e7687dfbc6ee61fa9aace8d4
+    refspec: 649f9d9e0ae64a5bb1f74f6d6edf678327d1dbf6
 
 distro: ics-dm-os
 

--- a/kas/distro/poky.yaml
+++ b/kas/distro/poky.yaml
@@ -8,7 +8,7 @@ distro: poky
 repos:
   ext/poky:
     url: "https://git.yoctoproject.org/git/poky"
-    refspec: yocto-3.1.16
+    refspec: yocto-3.1.17
     layers:
       meta:
       meta-poky:

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -6,10 +6,10 @@ header:
 repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
-    refspec: 5caf54c03e8c2e80d078fd230f28e23463765ae5
+    refspec: 303df2999e4ba8f051c3d497b0f4f807f77fcef0
   ext/meta-freescale:
     url: "https://github.com/Freescale/meta-freescale.git"
-    refspec: 6d2922bee372157454e422df518b6cf0bfcf6700
+    refspec: 3cb29cff92568ea835ef070490f185349d712837
 
 env:
   ACCEPT_FSL_EULA: "0"


### PR DESCRIPTION
 - poky: update to 3.1.17
 - meta-openembedded, meta-swupdate, meta-phytec, meta-freescale: update to latest dunfell head
 - Readme: added `scp` usage for new openssh clients (>=9.0)