### PR TITLE
updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [kirkstone-0.3.11] Q3 2022
+- kas:
+  - updated poky to 4.0.3
+  - updated to latest meta-openembedded
+  - updated to latest meta-swupdate
+  - updated to latest meta-virtualization
+- azure-iot-c-sdk,iot-identity-service: adapted openssl patches to openssl 3.0.5
+
 ## [kirkstone-0.3.10] Q3 2022
 - always link overlayfs to linux kernel, instead of using loadable module:
   - static linking of overlayfs is enforced by the (optional) layer meta-virtualization

--- a/kas/distro/ics-dm-os.yaml
+++ b/kas/distro/ics-dm-os.yaml
@@ -9,7 +9,7 @@ repos:
   meta-ics-dm:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    refspec: b9bbc38bfba702194a71c5a9dcb747ddacc9d66b
+    refspec: acbe74879807fc6f82b62525d32c823899e19036
     layers:
       meta-filesystems:
       meta-networking:
@@ -27,7 +27,7 @@ repos:
         path: "kas/patches/meta-rust-kirkstone-compatibility.patch"
   ext/meta-swupdate:
     url: "https://github.com/sbabic/meta-swupdate.git"
-    refspec: e6e2b70159dfd40067a65c07aca91ec31931629b
+    refspec: fabbcc623d41794fbfa97c38b9da941ed2cdcdcc
 
 distro: ics-dm-os
 

--- a/kas/distro/poky.yaml
+++ b/kas/distro/poky.yaml
@@ -8,7 +8,7 @@ distro: poky
 repos:
   ext/poky:
     url: "https://git.yoctoproject.org/git/poky"
-    refspec: yocto-4.0.2
+    refspec: yocto-4.0.3
     layers:
       meta:
       meta-poky:

--- a/kas/feature/iotedge.yaml
+++ b/kas/feature/iotedge.yaml
@@ -6,7 +6,7 @@ header:
 repos:
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/git/meta-virtualization"
-    refspec: 33fb354402b8875602a5746c1ad58528c8757c47
+    refspec: 26a361a39ff5ab6fae22efbdc582f84d13330ba2
 
 local_conf_header:
   meta-ics-dm_feature_iotedge: |

--- a/recipes-azure-iot/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
+++ b/recipes-azure-iot/azure-iot-sdk-c/azure-iot-sdk-c_git.bb
@@ -8,7 +8,7 @@ SRC_URI = "gitsm://github.com/Azure/azure-iot-sdk-c.git;branch=lts_01_2022;tag=L
 PV = "${SRCPV}"
 
 SRC_URI += " \
-    file://0001-adapt-for-openssl-3.0.3.patch \
+    file://openssl-3.0.5.patch \
 "
 
 S = "${WORKDIR}/git"

--- a/recipes-azure-iot/azure-iot-sdk-c/files/openssl-3.0.5.patch
+++ b/recipes-azure-iot/azure-iot-sdk-c/files/openssl-3.0.5.patch
@@ -1,16 +1,6 @@
-From c170bf93336f5701d106154071e2dbc84555004c Mon Sep 17 00:00:00 2001
-From: Kas User <kas@example.com>
-Date: Fri, 6 May 2022 07:44:05 +0000
-Subject: [PATCH] adapt for openssl 3.0.2
-
----
- c-utility/CMakeLists.txt           | 2 +-
- c-utility/adapters/tlsio_openssl.c | 2 +-
- c-utility/adapters/x509_openssl.c  | 4 ++--
- 3 files changed, 4 insertions(+), 4 deletions(-)
-
-diff --git a/CMakeLists.txt b/CMakeLists.txt
-index deeaae7d..944bcef5 100644
+Submodule c-utility contains modified content
+diff --git a/c-utility/CMakeLists.txt b/c-utility/CMakeLists.txt
+index deeaae7d..0c3321cb 100644
 --- a/c-utility/CMakeLists.txt
 +++ b/c-utility/CMakeLists.txt
 @@ -176,7 +176,7 @@ elseif(LINUX) #LINUX OR APPLE
@@ -18,12 +8,12 @@ index deeaae7d..944bcef5 100644
      # Turn off warning that can not be fixed right now
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral")
 -    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral")
-+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral -Wno-deprecated-declarations")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral -Wno-deprecated-declarations -Wno-discarded-qualifiers")
  elseif(APPLE)
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wformat-security")
      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat-security")
 diff --git a/c-utility/adapters/tlsio_openssl.c b/c-utility/adapters/tlsio_openssl.c
-index 4a3df849..3c7d9845 100644
+index 4a3df849..e75e301a 100644
 --- a/c-utility/adapters/tlsio_openssl.c
 +++ b/c-utility/adapters/tlsio_openssl.c
 @@ -953,7 +953,7 @@ static int add_certificate_to_store(TLS_IO_INSTANCE* tls_io_instance, const char
@@ -31,20 +21,20 @@ index 4a3df849..3c7d9845 100644
          else
          {
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER <= 0x30000030L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
              const BIO_METHOD* bio_method;
  #else
              BIO_METHOD* bio_method;
 diff --git a/c-utility/adapters/x509_openssl.c b/c-utility/adapters/x509_openssl.c
-index 5a9e5ac2..3a2afe2d 100644
+index 5a9e5ac2..df4abcfe 100644
 --- a/c-utility/adapters/x509_openssl.c
 +++ b/c-utility/adapters/x509_openssl.c
 @@ -75,7 +75,7 @@ static int load_certificate_chain(SSL_CTX* ssl_ctx, const char* certificate)
                  // certificates.
- 
+
                  /* Codes_SRS_X509_OPENSSL_07_006: [ If successful x509_openssl_add_ecc_credentials shall to import each certificate in the cert chain. ] */
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER <= 0x30000030L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                  SSL_CTX_clear_extra_chain_certs(ssl_ctx);
  #else
                  if (ssl_ctx->extra_certs != NULL)
@@ -53,10 +43,7 @@ index 5a9e5ac2..3a2afe2d 100644
          {
              /*Codes_SRS_X509_OPENSSL_02_012: [ x509_openssl_add_certificates shall get the memory BIO method function by calling BIO_s_mem. ]*/
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER <= 0x30000030L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
              const BIO_METHOD* bio_method;
  #else
              BIO_METHOD* bio_method;
--- 
-2.30.2
-

--- a/recipes-azure-iot/iot-identity-service/iot-identity-service/ossl300_aziot-tpm-sys.patch
+++ b/recipes-azure-iot/iot-identity-service/iot-identity-service/ossl300_aziot-tpm-sys.patch
@@ -7,7 +7,7 @@ index 7bbfa6f3..9d1989b0 100644
      # Turn off warning that can not be fixed right now
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral")
 -    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral")
-+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral -Wno-array-parameter -Wno-deprecated-declarations")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral -Wno-array-parameter -Wno-deprecated-declarations -Wno-discarded-qualifiers")
  elseif(APPLE)
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wformat-security")
      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat-security")
@@ -21,7 +21,7 @@ index a73c129c..c621c861 100644
          else
          {
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER <= 0x30000030L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
              const BIO_METHOD* bio_method;
  #else
              BIO_METHOD* bio_method;
@@ -32,10 +32,10 @@ index 11be7a03..96993f40 100644
 +++ b/tpm/aziot-tpm-sys/azure-iot-hsm-c/deps/c-shared/adapters/x509_openssl.c
 @@ -73,7 +73,7 @@ static int load_certificate_chain(SSL_CTX* ssl_ctx, const char* certificate)
                  // certificates.
- 
+
                  /* Codes_SRS_X509_OPENSSL_07_006: [ If successful x509_openssl_add_ecc_credentials shall to import each certificate in the cert chain. ] */
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER <= 0x30000030L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                  SSL_CTX_clear_extra_chain_certs(ssl_ctx);
  #else
                  if (ssl_ctx->extra_certs != NULL)
@@ -44,11 +44,11 @@ index 11be7a03..96993f40 100644
          {
              /*Codes_SRS_X509_OPENSSL_02_012: [ x509_openssl_add_certificates shall get the memory BIO method function by calling BIO_s_mem. ]*/
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER <= 0x30000030L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
              const BIO_METHOD* bio_method;
  #else
              BIO_METHOD* bio_method;
--- 
+--
 2.30.2
 
 diff --git a/tpm/aziot-tpm-sys/azure-iot-hsm-c/deps/utpm/deps/c-utility/CMakeLists.txt b/tpm/aziot-tpm-sys/azure-iot-hsm-c/deps/utpm/deps/c-utility/CMakeLists.txt
@@ -60,7 +60,7 @@ index 7bbfa6f3..9d1989b0 100644
      # Turn off warning that can not be fixed right now
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral")
 -    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral")
-+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral -Wno-array-parameter -Wno-deprecated-declarations")
++    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-unused-variable -Wno-missing-braces -Wno-missing-field-initializers -Wno-format-nonliteral -Wno-array-parameter -Wno-deprecated-declarations -Wno-discarded-qualifiers")
  elseif(APPLE)
      set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wformat-security")
      set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wformat-security")
@@ -74,7 +74,7 @@ index a73c129c..c621c861 100644
          else
          {
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER <= 0x30000030L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
              const BIO_METHOD* bio_method;
  #else
              BIO_METHOD* bio_method;
@@ -85,10 +85,10 @@ index 11be7a03..96993f40 100644
 +++ b/tpm/aziot-tpm-sys/azure-iot-hsm-c/deps/utpm/deps/c-utility/adapters/x509_openssl.c
 @@ -73,7 +73,7 @@ static int load_certificate_chain(SSL_CTX* ssl_ctx, const char* certificate)
                  // certificates.
- 
+
                  /* Codes_SRS_X509_OPENSSL_07_006: [ If successful x509_openssl_add_ecc_credentials shall to import each certificate in the cert chain. ] */
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER <= 0x30000030L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
                  SSL_CTX_clear_extra_chain_certs(ssl_ctx);
  #else
                  if (ssl_ctx->extra_certs != NULL)
@@ -97,9 +97,9 @@ index 11be7a03..96993f40 100644
          {
              /*Codes_SRS_X509_OPENSSL_02_012: [ x509_openssl_add_certificates shall get the memory BIO method function by calling BIO_s_mem. ]*/
 -#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER < 0x20000000L)
-+#if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && (OPENSSL_VERSION_NUMBER <= 0x30000030L)
++#if (OPENSSL_VERSION_NUMBER >= 0x10100000L)
              const BIO_METHOD* bio_method;
  #else
              BIO_METHOD* bio_method;
--- 
+--
 2.30.2


### PR DESCRIPTION
- kas:
  - updated poky to 4.0.3
  - updated to latest meta-openembedded
  - updated to latest meta-swupdate
  - updated to latest meta-virtualization
- azure-iot-c-sdk,iot-identity-service: adapted openssl patches to openssl 3.0.5

Signed-off-by: Marcel Lilienthal <134974+mlilien@users.noreply.github.com>