### PR TITLE
Check u-boot environment configuration for phytec imx8mm boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [kirkstone-0.4.12] Q3 2022
+- phytec tauri-l, phytec polis: added consistency check of u-boot environment configuration with meta-phytec
+
 ## [kirkstone-0.4.11] Q3 2022
 - demo-portal-module: bumped to 0.5.10
 - iot-client-template-rs: bumped to 0.4.8

--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -28,3 +28,5 @@ ICS_DM_PART_SIZE_UBOOT_ENV = "64"
 
 # mask fw_env.config configuration of meta-phytec, we generate that ourselves
 BBMASK:append = " meta-phytec/recipes-bsp/u-boot/libubootenv_%.bbappend"
+
+MACHINEOVERRIDES .= ":phytec-imx8mm"

--- a/dynamic-layers/phytec/recipes-bsp/u-boot/u-boot-imx_%.bbappend
+++ b/dynamic-layers/phytec/recipes-bsp/u-boot/u-boot-imx_%.bbappend
@@ -3,3 +3,21 @@ SRC_URI += "\
     file://enable_boot_script.patch\
     file://enable_generic_console_fs_cmds.cfg\
 "
+
+check_config_value() {
+    local ics_dm_val="$1"
+    local uboot_conf_var="$2"
+
+    ics_dm_val="$(echo "${ics_dm_val} * 1024" | bc)" # multiply with 1024
+    uboot_conf_val=$(grep "^${uboot_conf_var}=" ${S}/phycore-imx8mm_defconfig/.config | awk -F '=' '{print $2}')
+    uboot_conf_val="$(printf '%d' ${uboot_conf_val})" # convert to decimal
+    if [ ${uboot_conf_val} -ne ${ics_dm_val} ]; then
+        bbfatal "mismatch for ${uboot_conf_var}: ${ics_dm_val} <-> ${uboot_conf_val}"
+    fi
+}
+
+do_configure:append:phytec-imx8mm() {
+    check_config_value "${@d.getVar('ICS_DM_PART_OFFSET_UBOOT_ENV1')}" CONFIG_ENV_OFFSET
+    check_config_value "${@d.getVar('ICS_DM_PART_OFFSET_UBOOT_ENV2')}" CONFIG_ENV_OFFSET_REDUND
+    check_config_value "${@d.getVar('ICS_DM_PART_SIZE_UBOOT_ENV')}"    CONFIG_ENV_SIZE
+}


### PR DESCRIPTION
For phytec imx8mm boards, the u-boot environment offsets and size have to aligned with the u-boot configuration set by meta-phytec.