### PR TITLE
iot-identity-service: revert kirkstone-0.5.2 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [kirkstone-0.5.3] Q3 2022
+- iot-identity-service: revert kirkstone-0.5.2 (it's not recommended to synchronize with
+  systemd-udev-settle and it didn't help anyway)
+
 ## [kirkstone-0.5.2] Q3 2022
 - iot-identity-service: fixed race condition between tpm udev rule and `aziot-tpmd`
 

--- a/recipes-azure-iot/iot-identity-service/iot-identity-service_1.4.0.bb
+++ b/recipes-azure-iot/iot-identity-service/iot-identity-service_1.4.0.bb
@@ -386,7 +386,7 @@ do_install() {
     if ${@bb.utils.contains('MACHINE_FEATURES', 'tpm2', 'true', 'false', d)}; then
         install -m 0644     ${S}/tpm/aziot-tpmd/aziot-tpmd.service.in ${D}${systemd_system_unitdir}/aziot-tpmd.service
         sed -i \
-            -e 's/^After=\(.*\)$/After=\1 systemd-tmpfiles-setup.service systemd-udev-settle.service dev-tpmrm0.device/' \
+            -e 's/^After=\(.*\)$/After=\1 systemd-tmpfiles-setup.service dev-tpmrm0.device/' \
             -e 's#^After=\(.*\)$#After=\1\nConditionPathExists=/etc/aziot/config.toml\nConditionPathExists=/etc/aziot/identityd/config.d/00-super.toml#' \
             -e 's#@libexecdir@#/usr/libexec#g' \
             -e '/Environment=\(.*\)$/d' \


### PR DESCRIPTION
(it's not recommended to synchronize with systemd-udev-settle and it didn't help anyway)
