### PR TITLE
phytec: enable hardware watchdog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [kirkstone-0.9.0] Q4 2022
+- phygate-tauri-l, phyboard-polis: enabled hardware watchdog
+
 ## [kirkstone-0.8.4] Q4 2022
 - phytec u-boot: provide bootcmd_pxe
 

--- a/README.device.md
+++ b/README.device.md
@@ -1,10 +1,10 @@
 # BSP Features
-| device                                                                                             | wifi | bluetooth | rtc | tpm | gpt partition | pxe boot | sdcard boot | emmc boot | uart (uboot + linux) | PoR detect |
-|-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
-| [raspberrypi4-64](https://www.raspberrypi.org/)                                                    | x    | x         | o?  | o¹  | x²            | x        | x           | -         | x                    | x          |
-| [raspberrypi3](https://www.raspberrypi.org/)                                                       | x    | x         | o?  | o¹  | -             | todo     | x           | -         | x                    | ?          |
-| [phyboard-polis-imx8mm-4](https://www.phytec.eu/product-eu/single-board-computer/phyboard-polis/)  | x    | x         | x   | x   | x²            | todo     | x           | ?         | x                    | x          |
-| [phygate-tauri-l-imx8mm-2](https://www.phytec.eu/en/produkte/fertige-geraete-oem/phygate-tauri-l/) | ?    | ?         | ?   | ?   | ?             | todo     | x           | x³        | x                    | x          |
+| device                                                                                             | wifi | bluetooth | rtc | tpm | gpt partition | pxe boot | sdcard boot | emmc boot | uart (uboot + linux) | PoR detect | Hardware Watchdog |
+|-|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
+| [raspberrypi4-64](https://www.raspberrypi.org/)                                                    | x    | x         | o?  | o¹  | x²            | x        | x           | -         | x                    | x          | x                 |
+| [raspberrypi3](https://www.raspberrypi.org/)                                                       | x    | x         | o?  | o¹  | -             | todo     | x           | -         | x                    | ?          | ?                 |
+| [phyboard-polis-imx8mm-4](https://www.phytec.eu/product-eu/single-board-computer/phyboard-polis/)  | x    | x         | x   | x   | x²            | todo     | x           | ?         | x                    | x          | ?                 |
+| [phygate-tauri-l-imx8mm-2](https://www.phytec.eu/en/produkte/fertige-geraete-oem/phygate-tauri-l/) | ?    | ?         | ?   | ?   | ?             | todo     | x           | x³        | x                    | x          | x                 |
 
 | |  |
 |-|-:|

--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -28,3 +28,8 @@ ICS_DM_PART_SIZE_UBOOT_ENV = "64"
 
 # mask fw_env.config configuration of meta-phytec, we generate that ourselves
 BBMASK:append = " meta-phytec/recipes-bsp/u-boot/libubootenv_%.bbappend"
+
+# configure hardware watchdog
+# the maximum watchdog deadline depends on the hardware capabilities
+SYSTEMD_RuntimeWatchdogSec  = "60"
+SYSTEMD_RebootWatchdogSec   = "60"

--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -58,14 +58,24 @@ do_install:append() {
     ln -rs ${D}${systemd_system_unitdir}/systemd-time-wait-sync.service ${D}${sysconfdir}/systemd/system/sysinit.target.wants/systemd-time-wait-sync.service
 }
 
-# for rpi3 and rpi4, use hardware watchdog (see MACHINEOVERRIDES)
-do_install:append:rpi() {
+enable_hardware_watchdog() {
     local cfg_file="${D}${sysconfdir}/systemd/system.conf"
 
     [ -n "${SYSTEMD_RuntimeWatchdogSec}"  ] && \
-        sed -i 's|^#RuntimeWatchdogSec=.*$|RuntimeWatchdogSec=${SYSTEMD_RuntimeWatchdogSec}|' ${cfg_file}
+        sed -i 's|^#\(RuntimeWatchdogSec\)=.*$|\1=${SYSTEMD_RuntimeWatchdogSec}|' ${cfg_file}
     [ -n "${SYSTEMD_RebootWatchdogSec}"   ] && \
-        sed -i 's|^#RebootWatchdogSec=.*$|RebootWatchdogSec=${SYSTEMD_RebootWatchdogSec}|' ${cfg_file}
+        sed -i 's|^#\(RebootWatchdogSec\)=.*$|\1=${SYSTEMD_RebootWatchdogSec}|' ${cfg_file}
+}
+
+# enable hardware watchdog for rpi3, rpi4, phygate tauri-l and phyboard polis (see MACHINEOVERRIDES)
+do_install:append:rpi() {
+    enable_hardware_watchdog
+}
+do_install:append:phygate-tauri-l-imx8mm-2() {
+    enable_hardware_watchdog
+}
+do_install:append:phyboard-polis-imx8mm-4() {
+    enable_hardware_watchdog
 }
 
 # adapt tauri-l systemd-networkd-wait-online.service state


### PR DESCRIPTION
tested on phygate tauri-l:
```
[root@phygate-tauri-l-imx8mm-2 ics-dm]# strace -p 1 -t -T -e ioctl 2>&1 | grep WDIOC_KEEPALIVE                                                                                  
12:50:37 ioctl(9, WDIOC_KEEPALIVE)      = 0 <0.000340>
12:51:07 ioctl(9, WDIOC_KEEPALIVE)      = 0 <0.000030>                                                                                                                          
12:51:37 ioctl(9, WDIOC_KEEPALIVE)      = 0 <0.000341>
12:52:00 ioctl(9, WDIOC_KEEPALIVE)      = 0 <0.000030>                                                                                                                          
^Z       
[1]+  Stopped                 strace -p 1 -t -T -e ioctl 2>&1 | grep WDIOC_KEEPALIVE
...
U-Boot 2021.04 (Jun 27 2022 - 09:03:32 +0000)                                                                                                                                   
        
CPU:   i.MX8MMQ rev1.0 1600 MHz (running at 1200 MHz)                                                                                                                           
CPU:   Industrial temperature grade (-40C to 105C) at 55C
Reset cause: WARM BOOT     
...
```
-> watchdog reset after ~1 minute the init was stopped