### PR TITLE
coredump handling + docker bash completion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [kirkstone-0.11.11] Q4 2022
+- systemd: enabled coredump handling distro-wide
+  (we currently use the default settings, which can be adapted or disabled in
+  /etc/systemd/coredump.conf)
+- docker: enabled bash-completion
+
 ## [kirkstone-0.11.10] Q4 2022
 - warn if `IMAGE_GEN_DEBUGFS` is `1` and `gdbserver` not part of the image
 

--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -12,6 +12,8 @@ INIT_MANAGER ?= "systemd"
 # Uids/gids created by systemd-sysusers could potentially clash with
 # uids/gids introduced by later update images.
 PACKAGECONFIG:remove:pn-systemd = "sysusers"
+# enable (configuring) coredump handling
+PACKAGECONFIG:append:pn-systemd = " coredump"
 
 JOURNALD_SystemMaxUse ?= "128M"
 

--- a/dynamic-layers/virtualization/recipes-containers/docker/docker-moby_git.bbappend
+++ b/dynamic-layers/virtualization/recipes-containers/docker/docker-moby_git.bbappend
@@ -1,0 +1,5 @@
+do_install:append () {
+    # install bash completion
+    install -m 0644 -D ${S}/cli/contrib/completion/bash/docker ${D}/${datadir}/bash-completion/completions/docker
+}
+FILES:${PN} += "${datadir}/bash-completion/completions"


### PR DESCRIPTION
- systemd: enabled coredump handling distro-wide
  (we currently use the default settings, which can be adapted or disabled in
  /etc/systemd/coredump.conf)
- docker: enabled bash-completion

Signed-off-by: Marcel Lilienthal <134974+mlilien@users.noreply.github.com>