### PR TITLE
poky 4.0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [kirkstone-0.18.16] Q2 2023
+- kas:
+  - updated poky to 4.0.10
+  - updated meta-openembedded to latest kirkstone HEAD
+  - updated meta-swupdate to latest kirkstone HEAD
+  - updated meta-virtualization to latest kirkstone HEAD
+  - updated meta-phytec to latest kirkstone HEAD
+  - updated meta-freescale to latest kirkstone HEAD
+  - changed ref to meta-imx to an explicit commit, since upstream moved the tag "rel_imx_5.15.71_2.2.0" in the past
+
 ## [kirkstone-0.18.15] Q2 2023
 - iot-hub-device-update:
   - return error on failed update validation
-  - allow retry triggered by cloud 
+  - allow retry triggered by cloud
 
 ## [kirkstone-0.18.14] Q2 2023
 - updated iot-identity-service to 1.4.4

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -9,7 +9,7 @@ repos:
   meta-omnect:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
-    refspec: 571e36e20e9d1f27af0eb4545291beeb64f280e2
+    refspec: 5f120a926b0fcd55cfe7565bb7ddf23661cad498
     layers:
       meta-filesystems:
       meta-networking:
@@ -24,10 +24,10 @@ repos:
       meta-tpm:
   ext/meta-swupdate:
     url: "https://github.com/sbabic/meta-swupdate.git"
-    refspec: fb01170b98cf9541d286ba5a890fb85d83949b91
+    refspec: 22e9aee741bbeffe05dd942212f26d2cb9f5f5b7
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
-    refspec: dde0ff9eaa301ec5bd3daf667c7966cf55404d26
+    refspec: 9d056f957b42e31f1c2c5bad0af1ab6c84b53ee6
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/distro/poky.yaml
+++ b/kas/distro/poky.yaml
@@ -8,7 +8,7 @@ distro: poky
 repos:
   ext/poky:
     url: "https://git.yoctoproject.org/git/poky"
-    refspec: yocto-4.0.9
+    refspec: yocto-4.0.10
     layers:
       meta:
       meta-poky:

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -6,14 +6,14 @@ header:
 repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
-    refspec: 72bfe6f42a5ad2cc221c0595712666348a1773dc
+    refspec: 829ce6f0d7b0e4cf8a5775ec74d437ba2238e4cf
     patches:
       p001:
         repo: "meta-omnect"
         path: "kas/patches/meta-phytec_do_not_overwrite_BBMASK.patch"
   ext/meta-freescale:
     url: "https://github.com/Freescale/meta-freescale.git"
-    refspec: 82cbf4e5adac1017adc1e4a2ce056c57b3148ba0
+    refspec: 63169d4ba8fd427b0a95c9e666864291e7c191ce
     patches:
       p001:
         repo: "meta-omnect"
@@ -23,7 +23,9 @@ repos:
     refspec: d5bbb487b2816dfc74984a78b67f7361ce404253
   ext/meta-imx:
     url: "https://github.com/nxp-imx/meta-imx.git"
-    refspec: rel_imx_5.15.71_2.2.0
+    # switched to explicit ref, since upstream moved the tag in the past
+    #refspec: rel_imx_5.15.71_2.2.0
+    refspec: 01df9917808c12ac561b417d2b1f3652a64cdab9
     layers:
       meta-bsp:
       meta-sdk:


### PR DESCRIPTION
kas:
  - updated poky to 4.0.10
  - updated meta-openembedded to latest kirkstone HEAD
  - updated meta-swupdate to latest kirkstone HEAD
  - updated meta-virtualization to latest kirkstone HEAD
  - updated meta-phytec to latest kirkstone HEAD
  - updated meta-freescale to latest kirkstone HEAD
  - changed ref to meta-imx to an explicit commit, since upstream moved the tag "rel_imx_5.15.71_2.2.0" in the past