### PR TITLE
procps: moved from `OMNECT_DEV_TOOLS_DEFAULT` to `IMAGE_INSTALL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [kirkstone-0.19.4] Q3 2023
+- procps: moved from `OMNECT_DEV_TOOLS_DEFAULT` to `IMAGE_INSTALL` (reason: iotedge needs "ps -e" option)
+
 ## [kirkstone-0.19.3] Q3 2023
 - initramfs: fixed race condition in flash-mode-2 causing test
   pipeline to fail with missing file wic.xz

--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -116,7 +116,6 @@ OMNECT_DEVEL_TOOLS = "\
     lsof \
     ltrace \
     mmc-utils \
-    procps \
     screen \
     strace \
     sysstat \

--- a/recipes-omnect/images/omnect-os-image.bb
+++ b/recipes-omnect/images/omnect-os-image.bb
@@ -45,6 +45,7 @@ IMAGE_INSTALL = "\
     systemd-analyze \
     e2fsprogs-tune2fs \
     jq \
+    procps \
     ${@oe.utils.conditional('OMNECT_RELEASE_IMAGE', '1', '', '${OMNECT_DEVEL_TOOLS}', d)} \
 "
 


### PR DESCRIPTION
 (reason: iotedge needs "ps -e" option)