### PR TITLE
iot-hub-device-update: fixed CancelApply for swupdate_handler_v1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [kirkstone-0.21.1] Q3 2023
+- iot-hub-device-update: fixed CancelApply for swupdate_handler_v1,
+  so that the correct revert function is called from the adu-swupdate.sh script
+
 ## [kirkstone-0.21.0] Q3 2023
 - added bootloader-env recipe: `bootloader_env.sh` as wrapper for
   `fw_{setenv,printenv}` (u-boot) vs `grub-editenv` (grub)

--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/0001-fix-cancel-apply-swupdate_handler_v1.patch
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/0001-fix-cancel-apply-swupdate_handler_v1.patch
@@ -1,0 +1,25 @@
+From 058520728e03a3da2ee758686dd0dfcdef28ee46 Mon Sep 17 00:00:00 2001
+From: JoergZeidler <62105035+JoergZeidler@users.noreply.github.com>
+Date: Mon, 18 Sep 2023 08:31:14 +0200
+Subject: [PATCH] fix CancelApply swupdate_handler_v1 (#27)
+
+---
+ .../step_handlers/swupdate_handler/src/swupdate_handler.cpp     | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp b/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
+index 8ecad89..a5825c1 100644
+--- a/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
++++ b/src/extensions/step_handlers/swupdate_handler/src/swupdate_handler.cpp
+@@ -479,7 +479,7 @@ static ADUC_Result CancelApply(const char* logFolder)
+ 
+     std::string command = adushconst::adu_shell;
+     std::vector<std::string> args{ adushconst::update_type_opt,       adushconst::update_type_microsoft_swupdate,
+-                                   adushconst::update_action_opt,     adushconst::update_action_apply,
++                                   adushconst::update_action_opt,     adushconst::update_action_rollback,
+                                    adushconst::target_log_folder_opt, logFolder };
+ 
+     std::string output;
+-- 
+2.34.1
+

--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update_git.bb
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update_git.bb
@@ -21,6 +21,7 @@ SRC_URI = " \
   file://0001-add-swupdate-user-consent-handler.patch \
   file://0001-retry-handling-on-failed-update-validation.patch \
   file://workaround-deprecated-declarations-openssl3.patch \
+  file://0001-fix-cancel-apply-swupdate_handler_v1.patch \
 "
 SRC_URI:append:eg500 = " file://swupdate_v1_grub.sh"
 


### PR DESCRIPTION
so that the correct revert function is called from the adu-swupdate.sh script