### PR TITLE
fix(rpi): systemd: set more meaningful hw watchdog configuration values

### DIFF
--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -24,8 +24,8 @@ OMNECT_WLAN0 = "wlan0"
 
 # configure hardware watchdog
 # the maximum watchdog deadline depends on the hardware capabilities
-SYSTEMD_RuntimeWatchdogSec  = "15"
-SYSTEMD_RebootWatchdogSec   = "15"
+SYSTEMD_RuntimeWatchdogSec  = "10"
+SYSTEMD_RebootWatchdogSec   = "180"
 
 # this machine uses uboot
 MACHINEOVERRIDES:prepend = "omnect_uboot:"


### PR DESCRIPTION
- set `RuntimeWatchdogSec` to 10sec - less then max possible 15sec
- set `RebootWatchdogSec` to a more meaningful value  of 3min 