### PR TITLE
fix(u-boot): don't use redundant-env-fragment.cfg for bootloader checksum computation

### DIFF
--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -38,4 +38,4 @@ MACHINEOVERRIDES:prepend = "omnect_uboot:"
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-u-boot - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-u-boot is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-u-boot = "ca5c49295fc5a68b6428282db6552c5fbb1700eef86d19d18da6fac544f4f93f"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-u-boot = "4a3830545d023d1441802b9089de377516d6f3fd6508e6745fbde7716da8ca26"

--- a/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -37,6 +37,9 @@ OMNECT_BOOTLOADER_CHECKSUM_FILES += "${OMNECT_THISDIR_SAVED}/u-boot-scr.bb"
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${OMNECT_THISDIR_SAVED}/u-boot/*"
 
 OMNECT_BOOTLOADER_CHECKSUM_FILES_GLOB_IGNORE = "${OMNECT_THISDIR_SAVED}/u-boot/.gitignore"
+# don't include files which are generated on build:
+OMNECT_BOOTLOADER_CHECKSUM_FILES_GLOB_IGNORE += "${OMNECT_THISDIR_SAVED}/u-boot/redundant-env-fragment.cfg"
+
 
 # copy configuration fragment from template, before SRC_URI is checked
 do_fetch:prepend() {


### PR DESCRIPTION
redundant-env-fragment.cfg is generated during build from redundant-env-fragment.cfg.template
