### PR TITLE
fix(rpi): update rpi-bootfiles to 1.20230509~buster

### DIFF
--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -38,4 +38,4 @@ MACHINEOVERRIDES:prepend = "omnect_uboot:"
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-u-boot - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-u-boot is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-u-boot = "4a3830545d023d1441802b9089de377516d6f3fd6508e6745fbde7716da8ca26"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-u-boot = "f7597ebab14d96ee0462748b29108a2448495a821e90666dcb8c936234437bc0"

--- a/dynamic-layers/raspberrypi/recipes-bsp/rpi-bootfiles/rpi-bootfiles.bbappend
+++ b/dynamic-layers/raspberrypi/recipes-bsp/rpi-bootfiles/rpi-bootfiles.bbappend
@@ -1,0 +1,3 @@
+# override meta-raspberrypi kirkstone firmware version
+RPIFW_DATE = "20230509~buster"
+SRC_URI[sha256sum] = "1d9eb83111826b708f461101766fd2000d45f1c171ad573936d000f623ca8098"

--- a/dynamic-layers/raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/dynamic-layers/raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -15,6 +15,7 @@ OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_raspberrypi}/recipes-bsp/u-boot/
 # we have to update the raspberrypi firmware if basic configuration of the bsp changes
 # per convention such changes should be made in the following file:
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_omnect}/conf/machine/include/rpi_firmware_settings.inc"
+OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_omnect}/dynamic-layers/raspberrypi/recipes-bsp/rpi-bootfiles/*"
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_raspberrypi}/recipes-bsp/bootfiles/*"
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_raspberrypi}/recipes-bsp/common/*"
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${@bb.utils.contains('MACHINE_FEATURES', 'armstub', '${LAYERDIR_raspberrypi}/recipes-bsp/armstubs/*', '', d)}"


### PR DESCRIPTION
so that device tree files and firmware is in sync with kernel update from
https://github.com/agherzan/meta-raspberrypi/pull/1257
(fixes boot problems, were devices were stuck in rpi bootloader)