### PR TITLE
feat(ssh): let sshd determine ssh tunnel principal

### DIFF
--- a/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/recipes-connectivity/openssh/openssh_%.bbappend
@@ -3,6 +3,7 @@ do_install:append() {
     if ${@bb.utils.contains('OMNECT_RELEASE_IMAGE', '1', 'true', 'false', d)}; then
         sed -i -e 's/^#PasswordAuthentication\(.*\)/PasswordAuthentication no/g' ${D}${sysconfdir}/ssh/sshd_config
     fi
-    sed -i -e 's|^#AuthorizedPrincipalsFile\(.*\)|AuthorizedPrincipalsFile /mnt/cert/ssh/authorized_principals|' ${D}${sysconfdir}/ssh/sshd_config
+    echo "AuthorizedPrincipalsCommand /usr/bin/omnect_get_deviceid.sh" >> ${D}${sysconfdir}/ssh/sshd_config
+    echo "AuthorizedPrincipalsCommandUser sshd" >> ${D}${sysconfdir}/ssh/sshd_config
     echo "TrustedUserCAKeys /mnt/cert/ssh/root_ca" >> ${D}${sysconfdir}/ssh/sshd_config
 }


### PR DESCRIPTION
We use the device id as principal for the ssh tunnel user. Until now we therefore would inject a device id into the file. However, sshd can itself retrieve this information via the AuthorizedPrincipalsCommand. With this we adjust the configuration to use the "omnect_get_deviceid.sh" script so that sshd can retrieve its config itself.