### PR TITLE
fix(omnect-device-service): disable broken modem_info feature

### DIFF
--- a/recipes-omnect/omnect-device-service/omnect-device-service.inc
+++ b/recipes-omnect/omnect-device-service/omnect-device-service.inc
@@ -43,7 +43,6 @@ inherit omnect-device-service omnect_rust omnect_rust_azure-iot-sdk_deps systemd
 
 CARGO_BUILD_FLAGS:append:omnect_grub = " --features=bootloader_grub"
 CARGO_BUILD_FLAGS:append:omnect_uboot = " --features=bootloader_uboot"
-CARGO_BUILD_FLAGS:append = "${@bb.utils.contains('MACHINE_FEATURES', '3g', ',modem_info', '', d)}"
 
 do_install:append() {
     install -m 0644 -D ${S}/systemd/omnect-device-service.service ${D}${systemd_system_unitdir}/omnect-device-service.service


### PR DESCRIPTION
Currently, the modem_info feature does not work reliably on all target platforms. This has the effect that the omnect-device-service fails to start. With this commit we disable the feature until the problem has been resolved.