### PR TITLE
fix(omnect-device-service): re-enable modemmanager support

### DIFF
--- a/recipes-omnect/omnect-device-service/omnect-device-service.inc
+++ b/recipes-omnect/omnect-device-service/omnect-device-service.inc
@@ -43,6 +43,7 @@ inherit omnect-device-service omnect_rust omnect_rust_azure-iot-sdk_deps systemd
 
 CARGO_BUILD_FLAGS:append:omnect_grub = " --features=bootloader_grub"
 CARGO_BUILD_FLAGS:append:omnect_uboot = " --features=bootloader_uboot"
+CARGO_BUILD_FLAGS:append = "${@bb.utils.contains('MACHINE_FEATURES', '3g', ',modem_info', '', d)}"
 
 do_install:append() {
     install -m 0644 -D ${S}/systemd/omnect-device-service.service ${D}${systemd_system_unitdir}/omnect-device-service.service

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.19.1.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.19.1.bb
@@ -6,9 +6,9 @@ inherit cargo
 # DEFAULT_PREFERENCE = "-1"
 
 # how to get omnect-device-service could be as easy as but default to a git checkout:
-# SRC_URI += "crate://crates.io/omnect-device-service/0.19.0"
+# SRC_URI += "crate://crates.io/omnect-device-service/0.19.1"
 SRC_URI += "git://github.com/omnect/omnect-device-service.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "22eddfe47a79b27e0b86fd6cc726a1649350157d"
+SRCREV = "cd8643ee719c444e9a3bc18de547766f62f09002"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 
@@ -428,7 +428,7 @@ SRCREV_FORMAT .= "_http-common"
 SRCREV_http-common = "1.4.7"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/http-common"
 SRCREV_FORMAT .= "_modemmanager"
-SRCREV_modemmanager = "0.2.0"
+SRCREV_modemmanager = "0.3.0"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/modemmanager"
 SRCREV_FORMAT .= "_modemmanager-sys"
 SRCREV_modemmanager-sys = "0.1.0"


### PR DESCRIPTION
We bump the version of the omnect-device-service to 0.19.1 to reenable modemmanager support.