### PR TITLE
feat: enabled disabling bootloader version check

### DIFF
--- a/classes/omnect_bootloader_versioning.bbclass
+++ b/classes/omnect_bootloader_versioning.bbclass
@@ -93,7 +93,6 @@ python() {
             bb.debug(1, "overriding version_checksum %s -> %s" % (version_checksum,version_checksum_override_list[1]))
             version_checksum = version_checksum_override_list[1]
 
-
     version_checksum_expected = d.getVar("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED")
     if not version_checksum_expected:
         bb.fatal("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED not set; computed checksum is: \"%s\"" % version_checksum)

--- a/classes/omnect_bootloader_versioning.bbclass
+++ b/classes/omnect_bootloader_versioning.bbclass
@@ -94,12 +94,14 @@ python() {
             version_checksum = version_checksum_override_list[1]
 
 
-    if "1" != d.getVar("OMNECT_BOOTLOADER_VERSION_CHECK_DISABLE"):
-        version_checksum_expected = d.getVar("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED")
-        if not version_checksum_expected:
-            bb.fatal("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED not set; computed checksum is: \"%s\"" % version_checksum)
-        if version_checksum_expected != version_checksum:
+    version_checksum_expected = d.getVar("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED")
+    if not version_checksum_expected:
+        bb.fatal("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED not set; computed checksum is: \"%s\"" % version_checksum)
+    if version_checksum_expected != version_checksum:
+        if "1" != d.getVar("OMNECT_BOOTLOADER_VERSION_CHECK_DISABLE"):
             bb.fatal("expected bootloader checksum (OMNECT_BOOTLOADER_CHECKSUM_EXPECTED): \"%s\" is different from computed: \"%s\"" % (version_checksum_expected, version_checksum))
+        else:
+            bb.error("expected bootloader checksum (OMNECT_BOOTLOADER_CHECKSUM_EXPECTED): \"%s\" is different from computed: \"%s\"" % (version_checksum_expected, version_checksum))
 
     omnect_bootloader_version = d.getVar("PV") + "-" + version_checksum
     bootloader_version_file = d.getVar("DEPLOY_DIR_IMAGE") + "/omnect_bootloader_version"

--- a/classes/omnect_bootloader_versioning.bbclass
+++ b/classes/omnect_bootloader_versioning.bbclass
@@ -93,11 +93,13 @@ python() {
             bb.debug(1, "overriding version_checksum %s -> %s" % (version_checksum,version_checksum_override_list[1]))
             version_checksum = version_checksum_override_list[1]
 
-    version_checksum_expected = d.getVar("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED")
-    if not version_checksum_expected:
-        bb.fatal("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED not set; computed checksum is: \"%s\"" % version_checksum)
-    if version_checksum_expected != version_checksum:
-        bb.fatal("expected bootloader checksum (OMNECT_BOOTLOADER_CHECKSUM_EXPECTED): \"%s\" is different from computed: \"%s\"" % (version_checksum_expected, version_checksum))
+
+    if "1" != d.getVar("OMNECT_BOOTLOADER_VERSION_CHECK_DISABLE"):
+        version_checksum_expected = d.getVar("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED")
+        if not version_checksum_expected:
+            bb.fatal("OMNECT_BOOTLOADER_CHECKSUM_EXPECTED not set; computed checksum is: \"%s\"" % version_checksum)
+        if version_checksum_expected != version_checksum:
+            bb.fatal("expected bootloader checksum (OMNECT_BOOTLOADER_CHECKSUM_EXPECTED): \"%s\" is different from computed: \"%s\"" % (version_checksum_expected, version_checksum))
 
     omnect_bootloader_version = d.getVar("PV") + "-" + version_checksum
     bootloader_version_file = d.getVar("DEPLOY_DIR_IMAGE") + "/omnect_bootloader_version"


### PR DESCRIPTION
feat: enabled disabling bootloader version check by setting `OMNECT_BOOTLOADER_VERSION_CHECK_DISABLE=1`