### PR TITLE
chore: update to yocto 4.0.20

### DIFF
--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.0"
-    # tag yocto-4.0.19
-    commit: "5a90927f31c4f9fccbe5d9d07d08e6e69485baa8"
+    # tag yocto-4.0.20
+    commit: "734b0ea3dfe45eb16ee60f0c2c388e22af4040e0"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "kirkstone"
-    # tag yocto-4.0.19
-    commit: "ab2649ef6c83f0ae7cac554a72e6bea4dcda0e99"
+    # tag yocto-4.0.20
+    commit: "5d97b0576e98a2cf402abab1a1edcab223545d87"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "4.0.19"
+  OE_VERSION: "4.0.20"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -10,7 +10,7 @@ repos:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "kirkstone"
-    commit: "8e297cdc841c6cad34097f00a6903ba25edfc153"
+    commit: "4052c97dc83d0c88fc277d6fc1815e0699020daa"
     layers:
       meta-filesystems:
       meta-networking:
@@ -35,7 +35,7 @@ repos:
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "kirkstone"
-    commit: "8b356b91ed0d4bcab72350a2ddcef880f4fa5c26"
+    commit: "ef76369f844f8b5afea416372172824987ad4fec"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "kirkstone"
-    commit: "0efdd058d8e1f97f47fbd82007dfe9a3390a98bd"
+    commit: "e22b821a517de416aa3e9d9e79e22d7f95cff756"
     patches:
       p001:
         repo: "meta-omnect"
@@ -15,7 +15,7 @@ repos:
   ext/meta-freescale:
     url: "https://github.com/Freescale/meta-freescale.git"
     branch: "kirkstone"
-    commit: "fb17bfb8edcc9560bc1beb966a68f1f4c08ecfb3"
+    commit: "4c81b4161b99698b03332842b588dd8235ac47e4"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,8 +7,8 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: kirkstone
-    # yocto 4.0.19 (no tag)
-    commit: "6518f291d692997632304451695b6c194fec6fa6"
+    # yocto 4.0.20 (no tag)
+    commit: "c4c74d1e575217ddc4b74759cd83186a70940ef9"
     layers:
       meta-yocto-bsp:
 


### PR DESCRIPTION
updated openembedded-core + bitbake to yocto-4.0.20
updated meta-openembedded to latest kirkstone head
updated meta-virtualization to latest kirkstone head
updated meta-phytec to latest kirkstone head
updated meta-freescale to latest kirkstone head
updated meta-yocto repo to latest kirkstone head
