### PR TITLE
fix(docker): add handling to improve docker image pull operation during power cut

### DIFF
--- a/dynamic-layers/virtualization/recipes-containers/docker/docker-moby/0001-daemon-overlay2-Write-layer-metadata-atomically.patch
+++ b/dynamic-layers/virtualization/recipes-containers/docker/docker-moby/0001-daemon-overlay2-Write-layer-metadata-atomically.patch
@@ -1,0 +1,42 @@
+diff --git a/src/import/daemon/graphdriver/overlay2/overlay.go b/daemon/graphdriver/overlay2/overlay.go
+index 444f600f55..6614f62da0 100644
+--- a/src/import/daemon/graphdriver/overlay2/overlay.go
++++ b/src/import/daemon/graphdriver/overlay2/overlay.go
+@@ -23,6 +23,7 @@ import (
+ 	"github.com/docker/docker/pkg/directory"
+ 	"github.com/docker/docker/pkg/fsutils"
+ 	"github.com/docker/docker/pkg/idtools"
++	"github.com/docker/docker/pkg/ioutils"
+ 	"github.com/docker/docker/pkg/parsers"
+ 	"github.com/docker/docker/pkg/system"
+ 	"github.com/docker/docker/quota"
+@@ -400,7 +401,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
+ 	}
+
+ 	// Write link id to link file
+-	if err := os.WriteFile(path.Join(dir, "link"), []byte(lid), 0644); err != nil {
++	if err := ioutils.AtomicWriteFile(path.Join(dir, "link"), []byte(lid), 0o644); err != nil {
+ 		return err
+ 	}
+
+@@ -413,7 +414,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
+ 		return err
+ 	}
+
+-	if err := os.WriteFile(path.Join(d.dir(parent), "committed"), []byte{}, 0600); err != nil {
++	if err := ioutils.AtomicWriteFile(path.Join(d.dir(parent), "committed"), []byte{}, 0o600); err != nil {
+ 		return err
+ 	}
+
+@@ -422,7 +423,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
+ 		return err
+ 	}
+ 	if lower != "" {
+-		if err := os.WriteFile(path.Join(dir, lowerFile), []byte(lower), 0666); err != nil {
++		if err := ioutils.AtomicWriteFile(path.Join(dir, lowerFile), []byte(lower), 0o666); err != nil {
+ 			return err
+ 		}
+ 	}
+--
+2.39.2
+

--- a/dynamic-layers/virtualization/recipes-containers/docker/docker-moby_git.bbappend
+++ b/dynamic-layers/virtualization/recipes-containers/docker/docker-moby_git.bbappend
@@ -2,6 +2,7 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
 
 SRC_URI += "\
     file://daemon.json \
+    file://0001-daemon-overlay2-Write-layer-metadata-atomically.patch \
 "
 
 do_install:append () {


### PR DESCRIPTION
During power cycle tests, we have found multiple sporadically issues in case docker image pull operations and a device power cut.
Similar issues are reported here (https://github.com/moby/moby/issues/42964) and a fix was provided here (https://github.com/moby/moby/pull/46471).


