### PR TITLE
fix(bootloader-versioned): fix attempt for wrong artefact generation

### DIFF
--- a/recipes-bsp/u-boot/bootloader-versioned.bb
+++ b/recipes-bsp/u-boot/bootloader-versioned.bb
@@ -16,7 +16,11 @@ OMNECT_BOOTLOADER_EMBEDDED_VERSION_IMAGESIZE ?= ""
 OMNECT_BOOTLOADER_EMBEDDED_VERSION_LOCATION ?= ""
 OMNECT_BOOTLOADER_EMBEDDED_VERSION_IMAGESIZE ?= ""
 
-inherit deploy omnect_uboot_embedded_version
+# although not needed here for version calculation, nevertheless inherit class
+# omnect_bootloader_versioning to (hopefully) cause correct re-building of
+# verisioned bootlaoder artefact instead of matching an old version in SSTATE
+# cache
+inherit deploy omnect_bootloader_versioning omnect_uboot_embedded_version
 
 do_compile:append() {
     cp "${WORKDIR}/omnect_get_bootloader_version.sh.template" "${WORKDIR}/omnect_get_bootloader_version.sh"

--- a/recipes-bsp/u-boot/bootloader-versioned.bb
+++ b/recipes-bsp/u-boot/bootloader-versioned.bb
@@ -16,11 +16,12 @@ OMNECT_BOOTLOADER_EMBEDDED_VERSION_IMAGESIZE ?= ""
 OMNECT_BOOTLOADER_EMBEDDED_VERSION_LOCATION ?= ""
 OMNECT_BOOTLOADER_EMBEDDED_VERSION_IMAGESIZE ?= ""
 
-# although not needed here for version calculation, nevertheless inherit class
-# omnect_bootloader_versioning to (hopefully) cause correct re-building of
-# verisioned bootlaoder artefact instead of matching an old version in SSTATE
-# cache
-inherit deploy omnect_bootloader_versioning omnect_uboot_embedded_version
+inherit deploy omnect_uboot_embedded_version
+
+# relying on SSTATE cache showed that re-building of verisioned bootlaoder
+# artefact didn't work reliably, often an old version was unexpectedly used,
+# so switch off SSTATE for this recipe
+SKIP_SSTATE_CREATION = "1"
 
 do_compile:append() {
     cp "${WORKDIR}/omnect_get_bootloader_version.sh.template" "${WORKDIR}/omnect_get_bootloader_version.sh"

--- a/recipes-bsp/u-boot/bootloader-versioned.bb
+++ b/recipes-bsp/u-boot/bootloader-versioned.bb
@@ -20,7 +20,10 @@ inherit deploy omnect_uboot_embedded_version
 
 # relying on SSTATE cache showed that re-building of verisioned bootlaoder
 # artefact didn't work reliably, often an old version was unexpectedly used,
-# so switch off SSTATE for this recipe
+# even though above a dependency to u-boot-karo is defined through variable
+# OMNECT_BOOTLOADER_EMBEDDED_VERSION_BBTARGET.
+# so, switch off SSTATE for this recipe in the hope that this will cause
+# proper rebuilding.
 SKIP_SSTATE_CREATION = "1"
 
 do_compile:append() {


### PR DESCRIPTION
Added inheritance of class omnect_bootloader_versioning to recipe to hopefully yield complete dependencies for proper rebuild of versioned bootloader artefact also for 3rd party machines contained is extra meta layers.