### PR TITLE
chore(omnect-device-service): bump to 0.22.0 and extend privileges

### DIFF
--- a/classes/omnect-device-service.bbclass
+++ b/classes/omnect-device-service.bbclass
@@ -2,7 +2,7 @@ inherit aziot useradd
 
 # we create an omnect_device_socket user and group with static uid/gid 10000.
 # they can be used by containers (or other programs) on all image variants and versions
-# to get required socket permissions 
+# to get required socket permissions
 GROUPADD_PARAM:${PN} += " \
   -r adu; \
   -r omnect_device_service; \
@@ -11,7 +11,9 @@ GROUPADD_PARAM:${PN} += " \
 "
 
 # omnect-device-service.socket user and group
-USERADD_PARAM:${PN} += "--no-create-home -r -s /bin/false -u 10000 -g 10000 omnect_device_socket;"
+# aziotcs - allow reading certs under /var/lib/aziot/certd/certs/*
+# aziotks - allow reading keys under /var/lib/aziot/keyd/keys/*
+USERADD_PARAM:${PN} += "--no-create-home -r -s /bin/false -G aziotcs,aziotks -u 10000 -g 10000 omnect_device_socket;"
 
 # omnect-device-service needs groups rights for
 # adu - editing adu consent file

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/iot-identity-service.conf
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/iot-identity-service.conf
@@ -4,7 +4,7 @@ z /etc/aziot/config.toml 0664 root aziot -
 z /etc/aziot/certd 0750 root aziotcs -
 z /etc/aziot/certd/config.d 0700 aziotcs aziotcs -
 Z /etc/aziot/certd/config.d/\*.toml 0600 aziotcs aziotcs -
-d /var/lib/aziot/certd 0700 aziotcs aziotcs -
+d /var/lib/aziot/certd 0750 aziotcs aziotcs -
 d /var/lib/aziot/certd/certs 0755 aziotcs aziotcs -
 Z /var/lib/aziot/certd/certs/\*.cer 0644 aziotcs aziotcs -
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.22.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.22.0.bb
@@ -7,11 +7,11 @@ inherit cargo
 
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.22.0"
-SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=report_prov"
-SRCREV = "cbe0f39e79511b23264979ecbc47c4047ae01567"
+SRC_URI += "git://github.com/omnect/omnect-device-service.git;protocol=https;nobranch=1;branch=main"
+SRCREV = "ca7800bdd647a5914d2b9cf89809a3269e8979db"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
-PV:append = ".AUTOINC+cbe0f39e79"
+
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.22.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.22.0.bb
@@ -6,12 +6,12 @@ inherit cargo
 # DEFAULT_PREFERENCE = "-1"
 
 # how to get omnect-device-service could be as easy as but default to a git checkout:
-# SRC_URI += "crate://crates.io/omnect-device-service/0.21.0"
-SRC_URI += "git://github.com/omnect/omnect-device-service.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "f909d631d61aa1542ad30bfeecb4d25761fd88b7"
+# SRC_URI += "crate://crates.io/omnect-device-service/0.22.0"
+SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=report_prov"
+SRCREV = "cddf7bd5e966fd46c58e41f42f8abaaad249414c"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
-
+PV:append = ".AUTOINC+cddf7bd5e9"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched
@@ -34,12 +34,15 @@ SRC_URI += " \
     crate://crates.io/alloc-stdlib/0.2.2 \
     crate://crates.io/android-tzdata/0.1.1 \
     crate://crates.io/android_system_properties/0.1.5 \
-    crate://crates.io/anstyle/1.0.7 \
+    crate://crates.io/anstyle/1.0.8 \
     crate://crates.io/anyhow/1.0.86 \
+    crate://crates.io/asn1-rs-derive/0.5.1 \
+    crate://crates.io/asn1-rs-impl/0.2.0 \
+    crate://crates.io/asn1-rs/0.6.2 \
     crate://crates.io/assert-json-diff/2.0.2 \
     crate://crates.io/async-broadcast/0.5.1 \
     crate://crates.io/async-channel/2.3.1 \
-    crate://crates.io/async-executor/1.12.0 \
+    crate://crates.io/async-executor/1.13.0 \
     crate://crates.io/async-fs/1.6.0 \
     crate://crates.io/async-io/1.13.0 \
     crate://crates.io/async-io/2.3.3 \
@@ -47,9 +50,9 @@ SRC_URI += " \
     crate://crates.io/async-lock/3.4.0 \
     crate://crates.io/async-process/1.8.1 \
     crate://crates.io/async-recursion/1.1.1 \
-    crate://crates.io/async-signal/0.2.8 \
+    crate://crates.io/async-signal/0.2.9 \
     crate://crates.io/async-task/4.7.1 \
-    crate://crates.io/async-trait/0.1.80 \
+    crate://crates.io/async-trait/0.1.81 \
     crate://crates.io/atomic-waker/1.1.2 \
     crate://crates.io/autocfg/1.3.0 \
     crate://crates.io/backtrace/0.3.73 \
@@ -65,9 +68,9 @@ SRC_URI += " \
     crate://crates.io/brotli/6.0.0 \
     crate://crates.io/bumpalo/3.16.0 \
     crate://crates.io/byteorder/1.5.0 \
-    crate://crates.io/bytes/1.6.0 \
+    crate://crates.io/bytes/1.6.1 \
     crate://crates.io/bytestring/1.3.1 \
-    crate://crates.io/cc/1.0.104 \
+    crate://crates.io/cc/1.1.7 \
     crate://crates.io/cexpr/0.6.0 \
     crate://crates.io/cfg-if/1.0.0 \
     crate://crates.io/cfg_aliases/0.2.1 \
@@ -84,13 +87,16 @@ SRC_URI += " \
     crate://crates.io/crossbeam-channel/0.5.13 \
     crate://crates.io/crossbeam-utils/0.8.20 \
     crate://crates.io/crypto-common/0.1.6 \
-    crate://crates.io/darling/0.20.9 \
-    crate://crates.io/darling_core/0.20.9 \
-    crate://crates.io/darling_macro/0.20.9 \
+    crate://crates.io/darling/0.20.10 \
+    crate://crates.io/darling_core/0.20.10 \
+    crate://crates.io/darling_macro/0.20.10 \
+    crate://crates.io/data-encoding/2.6.0 \
+    crate://crates.io/der-parser/9.0.0 \
     crate://crates.io/deranged/0.3.11 \
     crate://crates.io/derivative/2.2.0 \
     crate://crates.io/derive_more/0.99.18 \
     crate://crates.io/digest/0.10.7 \
+    crate://crates.io/displaydoc/0.2.5 \
     crate://crates.io/dotenvy/0.15.7 \
     crate://crates.io/downcast/0.11.0 \
     crate://crates.io/either/1.13.0 \
@@ -98,8 +104,8 @@ SRC_URI += " \
     crate://crates.io/enum_dispatch/0.3.13 \
     crate://crates.io/enumflags2/0.7.10 \
     crate://crates.io/enumflags2_derive/0.7.10 \
-    crate://crates.io/env_filter/0.1.0 \
-    crate://crates.io/env_logger/0.11.3 \
+    crate://crates.io/env_filter/0.1.2 \
+    crate://crates.io/env_logger/0.11.5 \
     crate://crates.io/equivalent/1.0.1 \
     crate://crates.io/errno/0.3.9 \
     crate://crates.io/event-listener-strategy/0.5.2 \
@@ -145,7 +151,7 @@ SRC_URI += " \
     crate://crates.io/home/0.5.9 \
     crate://crates.io/http-body-util/0.1.2 \
     crate://crates.io/http-body/0.4.6 \
-    crate://crates.io/http-body/1.0.0 \
+    crate://crates.io/http-body/1.0.1 \
     crate://crates.io/http/0.2.12 \
     crate://crates.io/http/1.1.0 \
     crate://crates.io/httparse/1.9.4 \
@@ -156,8 +162,8 @@ SRC_URI += " \
     crate://crates.io/hyper-timeout/0.5.1 \
     crate://crates.io/hyper-tls/0.6.0 \
     crate://crates.io/hyper-util/0.1.6 \
-    crate://crates.io/hyper/0.14.29 \
-    crate://crates.io/hyper/1.4.0 \
+    crate://crates.io/hyper/0.14.30 \
+    crate://crates.io/hyper/1.4.1 \
     crate://crates.io/iana-time-zone-haiku/0.1.2 \
     crate://crates.io/iana-time-zone/0.1.60 \
     crate://crates.io/ident_case/1.0.1 \
@@ -171,7 +177,7 @@ SRC_URI += " \
     crate://crates.io/ipnet/2.9.0 \
     crate://crates.io/itertools/0.12.1 \
     crate://crates.io/itoa/1.0.11 \
-    crate://crates.io/jobserver/0.1.31 \
+    crate://crates.io/jobserver/0.1.32 \
     crate://crates.io/js-sys/0.3.69 \
     crate://crates.io/kqueue-sys/1.0.4 \
     crate://crates.io/kqueue/1.0.8 \
@@ -179,7 +185,7 @@ SRC_URI += " \
     crate://crates.io/lazy_static/1.5.0 \
     crate://crates.io/lazycell/1.3.0 \
     crate://crates.io/libc/0.2.155 \
-    crate://crates.io/libloading/0.8.4 \
+    crate://crates.io/libloading/0.8.5 \
     crate://crates.io/linked-hash-map/0.5.6 \
     crate://crates.io/linked_hash_set/0.1.4 \
     crate://crates.io/linux-raw-sys/0.3.8 \
@@ -196,6 +202,7 @@ SRC_URI += " \
     crate://crates.io/minimal-lexical/0.2.1 \
     crate://crates.io/miniz_oxide/0.7.4 \
     crate://crates.io/mio/0.8.11 \
+    crate://crates.io/mio/1.0.1 \
     crate://crates.io/mockall/0.12.1 \
     crate://crates.io/mockall_derive/0.12.1 \
     crate://crates.io/native-tls/0.2.12 \
@@ -214,13 +221,13 @@ SRC_URI += " \
     crate://crates.io/num-rational/0.4.2 \
     crate://crates.io/num-traits/0.2.19 \
     crate://crates.io/num/0.4.3 \
-    crate://crates.io/num_cpus/1.16.0 \
-    crate://crates.io/object/0.36.1 \
+    crate://crates.io/object/0.36.2 \
+    crate://crates.io/oid-registry/0.7.0 \
     crate://crates.io/once_cell/1.19.0 \
     crate://crates.io/openssl-macros/0.1.1 \
     crate://crates.io/openssl-probe/0.1.5 \
-    crate://crates.io/openssl-sys/0.9.102 \
-    crate://crates.io/openssl/0.10.64 \
+    crate://crates.io/openssl-sys/0.9.103 \
+    crate://crates.io/openssl/0.10.66 \
     crate://crates.io/ordered-stream/0.2.0 \
     crate://crates.io/parking/2.2.0 \
     crate://crates.io/parking_lot/0.12.3 \
@@ -236,10 +243,10 @@ SRC_URI += " \
     crate://crates.io/polling/2.8.0 \
     crate://crates.io/polling/3.7.2 \
     crate://crates.io/powerfmt/0.2.0 \
-    crate://crates.io/ppv-lite86/0.2.17 \
-    crate://crates.io/predicates-core/1.0.6 \
-    crate://crates.io/predicates-tree/1.0.9 \
-    crate://crates.io/predicates/3.1.0 \
+    crate://crates.io/ppv-lite86/0.2.18 \
+    crate://crates.io/predicates-core/1.0.8 \
+    crate://crates.io/predicates-tree/1.0.11 \
+    crate://crates.io/predicates/3.1.2 \
     crate://crates.io/prettyplease/0.2.20 \
     crate://crates.io/proc-macro-crate/1.3.1 \
     crate://crates.io/proc-macro2/1.0.86 \
@@ -248,7 +255,7 @@ SRC_URI += " \
     crate://crates.io/rand_chacha/0.3.1 \
     crate://crates.io/rand_core/0.6.4 \
     crate://crates.io/redox_syscall/0.4.1 \
-    crate://crates.io/redox_syscall/0.5.2 \
+    crate://crates.io/redox_syscall/0.5.3 \
     crate://crates.io/regex-automata/0.4.7 \
     crate://crates.io/regex-lite/0.1.6 \
     crate://crates.io/regex-syntax/0.8.4 \
@@ -258,30 +265,32 @@ SRC_URI += " \
     crate://crates.io/rustc-demangle/0.1.24 \
     crate://crates.io/rustc-hash/1.1.0 \
     crate://crates.io/rustc_version/0.4.0 \
+    crate://crates.io/rusticata-macros/4.1.0 \
     crate://crates.io/rustix/0.37.27 \
     crate://crates.io/rustix/0.38.34 \
     crate://crates.io/rustls-pemfile/2.1.2 \
     crate://crates.io/rustls-pki-types/1.7.0 \
-    crate://crates.io/rustls-webpki/0.102.4 \
-    crate://crates.io/rustls/0.23.10 \
+    crate://crates.io/rustls-webpki/0.102.6 \
+    crate://crates.io/rustls/0.23.12 \
     crate://crates.io/rustversion/1.0.17 \
     crate://crates.io/ryu/1.0.18 \
     crate://crates.io/same-file/1.0.6 \
     crate://crates.io/schannel/0.1.23 \
     crate://crates.io/scopeguard/1.2.0 \
-    crate://crates.io/sd-notify/0.4.1 \
-    crate://crates.io/security-framework-sys/2.11.0 \
-    crate://crates.io/security-framework/2.11.0 \
+    crate://crates.io/sd-notify/0.4.2 \
+    crate://crates.io/security-framework-sys/2.11.1 \
+    crate://crates.io/security-framework/2.11.1 \
     crate://crates.io/semver/1.0.23 \
-    crate://crates.io/serde/1.0.203 \
-    crate://crates.io/serde_derive/1.0.203 \
-    crate://crates.io/serde_json/1.0.120 \
+    crate://crates.io/serde/1.0.204 \
+    crate://crates.io/serde_derive/1.0.204 \
+    crate://crates.io/serde_json/1.0.121 \
     crate://crates.io/serde_repr/0.1.19 \
+    crate://crates.io/serde_spanned/0.6.7 \
     crate://crates.io/serde_urlencoded/0.7.1 \
     crate://crates.io/serde_with/2.3.3 \
-    crate://crates.io/serde_with/3.8.2 \
+    crate://crates.io/serde_with/3.9.0 \
     crate://crates.io/serde_with_macros/2.3.3 \
-    crate://crates.io/serde_with_macros/3.8.2 \
+    crate://crates.io/serde_with_macros/3.9.0 \
     crate://crates.io/sha1/0.10.6 \
     crate://crates.io/shlex/1.3.0 \
     crate://crates.io/signal-hook-registry/1.4.2 \
@@ -299,28 +308,31 @@ SRC_URI += " \
     crate://crates.io/strum_macros/0.26.4 \
     crate://crates.io/subtle/2.6.1 \
     crate://crates.io/syn/1.0.109 \
-    crate://crates.io/syn/2.0.68 \
+    crate://crates.io/syn/2.0.72 \
     crate://crates.io/sync_wrapper/1.0.1 \
+    crate://crates.io/synstructure/0.13.1 \
     crate://crates.io/system-configuration-sys/0.5.0 \
     crate://crates.io/system-configuration/0.5.1 \
     crate://crates.io/systemd-zbus/0.1.1 \
     crate://crates.io/tempfile/3.10.1 \
     crate://crates.io/termtree/0.4.1 \
-    crate://crates.io/thiserror-impl/1.0.61 \
-    crate://crates.io/thiserror/1.0.61 \
+    crate://crates.io/thiserror-impl/1.0.63 \
+    crate://crates.io/thiserror/1.0.63 \
     crate://crates.io/time-core/0.1.2 \
     crate://crates.io/time-macros/0.2.18 \
     crate://crates.io/time/0.3.36 \
-    crate://crates.io/tinyvec/1.6.1 \
+    crate://crates.io/tinyvec/1.8.0 \
     crate://crates.io/tinyvec_macros/0.1.1 \
-    crate://crates.io/tokio-macros/2.3.0 \
+    crate://crates.io/tokio-macros/2.4.0 \
     crate://crates.io/tokio-native-tls/0.3.1 \
     crate://crates.io/tokio-openssl/0.6.4 \
     crate://crates.io/tokio-rustls/0.26.0 \
     crate://crates.io/tokio-util/0.7.11 \
-    crate://crates.io/tokio/1.38.0 \
-    crate://crates.io/toml_datetime/0.6.6 \
+    crate://crates.io/tokio/1.39.2 \
+    crate://crates.io/toml/0.8.16 \
+    crate://crates.io/toml_datetime/0.6.7 \
     crate://crates.io/toml_edit/0.19.15 \
+    crate://crates.io/toml_edit/0.22.17 \
     crate://crates.io/tower-layer/0.3.2 \
     crate://crates.io/tower-service/0.3.2 \
     crate://crates.io/tower/0.4.13 \
@@ -335,9 +347,9 @@ SRC_URI += " \
     crate://crates.io/unicode-normalization/0.1.23 \
     crate://crates.io/untrusted/0.9.0 \
     crate://crates.io/url/2.5.2 \
-    crate://crates.io/uuid/1.9.1 \
+    crate://crates.io/uuid/1.10.0 \
     crate://crates.io/vcpkg/0.2.15 \
-    crate://crates.io/version_check/0.9.4 \
+    crate://crates.io/version_check/0.9.5 \
     crate://crates.io/waker-fn/1.2.0 \
     crate://crates.io/walkdir/2.5.0 \
     crate://crates.io/want/0.3.1 \
@@ -358,36 +370,40 @@ SRC_URI += " \
     crate://crates.io/windows-sys/0.48.0 \
     crate://crates.io/windows-sys/0.52.0 \
     crate://crates.io/windows-targets/0.48.5 \
-    crate://crates.io/windows-targets/0.52.5 \
+    crate://crates.io/windows-targets/0.52.6 \
     crate://crates.io/windows_aarch64_gnullvm/0.48.5 \
-    crate://crates.io/windows_aarch64_gnullvm/0.52.5 \
+    crate://crates.io/windows_aarch64_gnullvm/0.52.6 \
     crate://crates.io/windows_aarch64_msvc/0.48.5 \
-    crate://crates.io/windows_aarch64_msvc/0.52.5 \
+    crate://crates.io/windows_aarch64_msvc/0.52.6 \
     crate://crates.io/windows_i686_gnu/0.48.5 \
-    crate://crates.io/windows_i686_gnu/0.52.5 \
-    crate://crates.io/windows_i686_gnullvm/0.52.5 \
+    crate://crates.io/windows_i686_gnu/0.52.6 \
+    crate://crates.io/windows_i686_gnullvm/0.52.6 \
     crate://crates.io/windows_i686_msvc/0.48.5 \
-    crate://crates.io/windows_i686_msvc/0.52.5 \
+    crate://crates.io/windows_i686_msvc/0.52.6 \
     crate://crates.io/windows_x86_64_gnu/0.48.5 \
-    crate://crates.io/windows_x86_64_gnu/0.52.5 \
+    crate://crates.io/windows_x86_64_gnu/0.52.6 \
     crate://crates.io/windows_x86_64_gnullvm/0.48.5 \
-    crate://crates.io/windows_x86_64_gnullvm/0.52.5 \
+    crate://crates.io/windows_x86_64_gnullvm/0.52.6 \
     crate://crates.io/windows_x86_64_msvc/0.48.5 \
-    crate://crates.io/windows_x86_64_msvc/0.52.5 \
+    crate://crates.io/windows_x86_64_msvc/0.52.6 \
     crate://crates.io/winnow/0.5.40 \
+    crate://crates.io/winnow/0.6.16 \
     crate://crates.io/winreg/0.52.0 \
+    crate://crates.io/x509-parser/0.16.0 \
     crate://crates.io/xdg-home/1.2.0 \
     crate://crates.io/zbus/3.14.1 \
     crate://crates.io/zbus_macros/3.14.1 \
     crate://crates.io/zbus_names/2.6.1 \
+    crate://crates.io/zerocopy-derive/0.6.6 \
     crate://crates.io/zerocopy-derive/0.7.35 \
+    crate://crates.io/zerocopy/0.6.6 \
     crate://crates.io/zerocopy/0.7.35 \
     crate://crates.io/zeroize/1.8.1 \
-    crate://crates.io/zstd-safe/7.1.0 \
-    crate://crates.io/zstd-sys/2.0.11+zstd.1.5.6 \
-    crate://crates.io/zstd/0.13.1 \
-    crate://crates.io/zvariant/3.15.1 \
-    crate://crates.io/zvariant_derive/3.15.1 \
+    crate://crates.io/zstd-safe/7.2.0 \
+    crate://crates.io/zstd-sys/2.0.12+zstd.1.5.6 \
+    crate://crates.io/zstd/0.13.2 \
+    crate://crates.io/zvariant/3.15.2 \
+    crate://crates.io/zvariant_derive/3.15.2 \
     crate://crates.io/zvariant_utils/1.0.1 \
     git://github.com/Azure/iot-identity-service.git;protocol=https;nobranch=1;name=aziot-cert-client-async;destsuffix=aziot-cert-client-async \
     git://github.com/Azure/iot-identity-service.git;protocol=https;nobranch=1;name=aziot-cert-common-http;destsuffix=aziot-cert-common-http \
@@ -447,7 +463,7 @@ SRCREV_FORMAT .= "_aziot-keyd-config"
 SRCREV_aziot-keyd-config = "1.5.0"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/aziot-keyd-config"
 SRCREV_FORMAT .= "_azure-iot-sdk"
-SRCREV_azure-iot-sdk = "0.13.1"
+SRCREV_azure-iot-sdk = "0.13.2"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/azure-iot-sdk"
 SRCREV_FORMAT .= "_azure-iot-sdk-sys"
 SRCREV_azure-iot-sdk-sys = "0.6.1"

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.22.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.22.0.bb
@@ -8,10 +8,10 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.22.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=report_prov"
-SRCREV = "cddf7bd5e966fd46c58e41f42f8abaaad249414c"
+SRCREV = "cbe0f39e79511b23264979ecbc47c4047ae01567"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
-PV:append = ".AUTOINC+cddf7bd5e9"
+PV:append = ".AUTOINC+cbe0f39e79"
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched


### PR DESCRIPTION
In order to allow reuse of device identity secret:
- give read access to /var/lib/aziot/certd/certs/* to omnect-device-service and omnect-device-socket user
- give read access to /var/lib/aziot/keyd/keys/* to omnect-device-service and omnect-device-socket user

Related PR's: https://github.com/omnect/omnect-ui/pull/8 and https://github.com/omnect/omnect-device-service/pull/98