### PR TITLE
revert: chore(omnect-device-service): bump to 0.22.2 (#490)

### DIFF
--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.22.1.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.22.1.bb
@@ -6,9 +6,9 @@ inherit cargo
 # DEFAULT_PREFERENCE = "-1"
 
 # how to get omnect-device-service could be as easy as but default to a git checkout:
-# SRC_URI += "crate://crates.io/omnect-device-service/0.22.2"
+# SRC_URI += "crate://crates.io/omnect-device-service/0.22.1"
 SRC_URI += "git://github.com/omnect/omnect-device-service.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "dd41b93fb3556c2deaa180d0f23cf14f8898cc19"
+SRCREV = "46bdd76acb61347233b1c237140877fbc19b18de"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 


### PR DESCRIPTION
This reverts commit a7534db8ae2f9aba93b3a32610e2d8da8d5f0f8c.