### PR TITLE
fix(shutdown): add missing systemd dependency containerd in docker.service

### DIFF
--- a/dynamic-layers/virtualization/recipes-containers/docker/docker-moby_git.bbappend
+++ b/dynamic-layers/virtualization/recipes-containers/docker/docker-moby_git.bbappend
@@ -10,6 +10,11 @@ do_install:append () {
     install -m 0644 -D ${S}/cli/contrib/completion/bash/docker ${D}/${datadir}/bash-completion/completions/docker
 
     install -m 0644 -D ${WORKDIR}/daemon.json ${D}${sysconfdir}/docker/daemon.json
+
+    sed -i \
+        -e 's/^After=\(.*\)$/After=\1 containerd.service/' \
+        -e 's/^Wants=\(.*\)$/Wants=\1 containerd.service/' \
+        ${D}/${systemd_unitdir}/system/docker.service
 }
 
 FILES:${PN} += " \


### PR DESCRIPTION
During shutdown or reboot of an iotedge device, the iotedge component stops running docker containers. This works only in case docker and containerd are still running.