### PR TITLE
refactor(factory-reset): initramfs: preserve array is now mandatory

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,9 @@ A custom configuration to preserve files from a factory reset is a json file in 
   ]
 }
 ```
-This example preserves the `bash_history` of the users `omnect` and `root`.
+This example preserves the `bash_history` of the users `omnect` and `root`.<br>
+Nonexisting files listed here, will produce a warning during the factory reset process, but will result in a success.<br>
+Note that home directories in the example above work, because they are actually located on the data partition via overlay mount. Paths which are not overlayed respectively not located in the data partition, will result in a failure of the factory reset on restore.
 
 #### Factory Reset Result
 In the case of an error during the backup of files or directories the whole factory reset will be aborted
@@ -427,9 +429,9 @@ The overall `factory reset status` consists of:
   - 1: wipe mode unsupported
   - 2: backup/restore failure
   - 3: configuration error; see "context" for details
-- `error`:  execution exit status. in case of of success == 0, if not applicaple: `-`.
+- `error`:  execution exit status; in case of of success == 0, if not applicaple: `-`
 - optional: `context` on warnings or errors
-- array `paths` of preserved files or directories
+- array `paths` of preserved files or directories; this array reflects the configured paths not the actual restored path, e.g. if a path doesn't exist
 
 ### Debug Mount Options of Data Partition
 

--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
@@ -13,7 +13,7 @@ function get() {
     [[ ${argsc} -ne 2 ]] && help && exit 1
     local key=${1}
     local value=$(grub-editenv ${grubenv} list | grep ^${key}=)
-    value=${value/${key}=}
+    value=${value#${key}=}
     [[ -z "${value}" ]] && echo && exit 2
     echo ${value}
 }

--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
@@ -12,7 +12,7 @@ function get() {
     [[ ${argsc} -ne 2 ]] && help && exit 1
     local key=${1}
     local value=$(fw_printenv ${key})
-    value=${value/${key}=}
+    value=${value#${key}=}
     [[ -z "${value}" ]] && echo && exit 2
     echo ${value}
 }

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/factory-reset
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/factory-reset
@@ -271,17 +271,21 @@ factory_reset_run() {
         local preserve_path="";
         for i in $(find ${ROOTFS_DIR}/etc/omnect/factory-reset.d/ -iname *.json); do
             preserve_path=$(jq -r -e '.paths' ${i}) || \
-                { handle_status "3" "-" "${i/${ROOTFS_DIR}}: no path object" "${preserve_list}"; return; }
+                { handle_status "3" "-" "${i/${ROOTFS_DIR}}: no path object" "${preserve_list[@]}"; return; }
             if [ "[]" != "${preserve_path}" ]; then
                 preserve_list+=( $(jq -r -e '.paths[]' ${i}) ) || \
-                    { handle_status "3" "${?}" "${i/${ROOTFS_DIR}}: couldn't parse paths array" "${preserve_list}"; return; }
+                    { handle_status "3" "${?}" "${i/${ROOTFS_DIR}}: couldn't parse paths array" "${preserve_list[@]}"; return; }
             fi
         done
     fi
 
     for key in "${preserve[@]}"; do
-        preserve_list+=( $(jq -r -e --arg key "${key}" .$key[] ${ROOTFS_DIR}/etc/omnect/factory-reset.json) ) || \
-            { handle_status "3" "${?}" "${ROOTFS_DIR}/etc/omnect/factory-reset.json:${key}" "${preserve_list[@]}"; return; }
+        preserve_path=$(jq -r -e --arg key "${key}" .$key ${ROOTFS_DIR}/etc/omnect/factory-reset.json) || \
+                { handle_status "3" "-" "${i/${ROOTFS_DIR}}: no ${key} object" "${preserve_list[@]}"; return; }
+        if [ "[]" != "${preserve_path}" ]; then
+            preserve_list+=( $(jq -r -e --arg key "${key}" .$key[] ${ROOTFS_DIR}/etc/omnect/factory-reset.json) ) || \
+                { handle_status "3" "${?}" "${ROOTFS_DIR}/etc/omnect/factory-reset.json:${key}" "${preserve_list[@]}"; return; }
+        fi
     done
 
     msg "factor-reset preserve_list=${preserve_list[@]}"

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/factory-reset
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/factory-reset
@@ -270,9 +270,12 @@ factory_reset_run() {
         preserve=( ${preserve[@]/applications} )
         local preserve_path="";
         for i in $(find ${ROOTFS_DIR}/etc/omnect/factory-reset.d/ -iname *.json); do
-            preserve_path=$(jq -r -e '.paths' ${i}) || { handle_status "3" "-" "${i/${ROOTFS_DIR}}: no path object" "${preserve_list}"; return; }
-            [[ "[]" != ${preserve_path} ]] && \
-                preserve_list+=( $(jq -r -e '.paths[]' ${i}) ) || { handle_status "3" "${?}" "${i/${ROOTFS_DIR}}: could parse paths array" "${preserve_list}"; return; }
+            preserve_path=$(jq -r -e '.paths' ${i}) || \
+                { handle_status "3" "-" "${i/${ROOTFS_DIR}}: no path object" "${preserve_list}"; return; }
+            if [ "[]" != "${preserve_path}" ]; then
+                preserve_list+=( $(jq -r -e '.paths[]' ${i}) ) || \
+                    { handle_status "3" "${?}" "${i/${ROOTFS_DIR}}: couldn't parse paths array" "${preserve_list}"; return; }
+            fi
         done
     fi
 

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/factory-reset
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/factory-reset
@@ -253,7 +253,7 @@ factory_reset_run() {
         return 1
     fi
     mode=$(echo "${factory_reset}" | jq -e -r '.mode') || { handle_status "1" "-" "mode not set" ""; return; }
-    preserve=$(echo "${factory_reset}" | jq -e -r '.preserve') || { handle_status "1" "-" "preserve object not set" ""; return; }
+    preserve=$(echo "${factory_reset}" | jq -e -r '.preserve') || { handle_status "3" "-" "preserve object not set" ""; return; }
     if [ "[]" != "${preserve}" ]; then
         preserve=($(echo "${factory_reset}" | jq -e -r '.preserve | .[]')) || { handle_status "3" "-" "could_not_parse_preserve_array" ""; return; }
     else

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/factory-reset
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/factory-reset
@@ -9,6 +9,7 @@
 factory_reset_backup_dir="/tmp/factory_reset/backup"
 factory_reset=""
 warnings=""
+mount=0
 
 # called by generic INITRAMFS
 factory_reset_enabled() {
@@ -134,15 +135,15 @@ factory_reset_restore() {
 
     while [[ "${destpath}" != "${ROOTFS_DIR}" ]]; do
         mountpoint -q ${destpath} && nested_mount=${destpath/${ROOTFS_DIR}} && break
-        destpath=${destpath%\/*}
+        destpath=$(dirname ${destpath})
     done
 
     # do restore, keep permissions and ownership
     if [ -n "${nested_mount}" ]; then
         msg "nested mount: ${factory_reset_backup_dir}/${ROOTFS_DIR}${nested_mount}"
         cd ${factory_reset_backup_dir}/${ROOTFS_DIR}${nested_mount}
-        path_name=${path_name/${nested_mount}}
-        run_cmd cp --parents -av "${path_name:1}" "${ROOTFS_DIR}${nested_mount}"
+        path_name=${path_name#${nested_mount}\/}
+        run_cmd cp --parents -av "${path_name}" "${ROOTFS_DIR}${nested_mount}"
         ret=$?
         cd - &>/dev/null
     else
@@ -157,7 +158,7 @@ factory_reset_restore() {
 
 iterate_restore_list() {
     local    do_backup="${1}"
-    local restore_list="${@:2}"
+    local restore_list=( "${@:2}" )
 
     local ret=0
     local status=0
@@ -189,6 +190,7 @@ iterate_restore_list() {
 }
 
 factory_reset_mount() {
+    mount=1
     mount_partition "ext4" "/dev/omnect/rootCurrent" "${ROOTFS_DIR}" "defaults,ro"
     mount_partition "ext4" "/dev/omnect/factory" "${ROOTFS_DIR}/mnt/factory" "defaults,ro"
     setup_etc_partition  "${ROOTFS_DIR}" "defaults,rw"
@@ -197,6 +199,7 @@ factory_reset_mount() {
 }
 
 factory_reset_umount() {
+    mount=0
     umount_persistent_var_log "${ROOTFS_DIR}"
     umount_data_partition "${ROOTFS_DIR}"
     umount_etc_partition  "${ROOTFS_DIR}"
@@ -210,7 +213,7 @@ handle_status() {
     local status=${1}
     local error=${2}
     local context=${3}
-    local preserve_paths=${@:4}
+    local preserve_paths=( "${@:4}" )
 
     msg "status: status=${status}, error=${error}, context=${context}, preserve_path=${preserve_paths[@]}"
     if [ -n "${warnings}" ]; then
@@ -234,21 +237,25 @@ handle_status() {
     fi
 }
 
+factory_reset_post () {
+    [[ ${mount} -eq 1 ]] && factory_reset_umount
+}
+
 # main entry point
 factory_reset_run() {
     local mode=""
     local preserve=""
-    # explictly no exit hook handling here
+
+    add_module_post_hook factory_reset_post
 
     if [ -z "${ROOTFS_DIR}" ]; then
         fatal "no ROOTFS_DIR"
         return 1
     fi
-    mode=$(echo "${factory_reset}" | jq -e -r '.mode') || { handle_status "1" "-" "mode_not_set" ""; return 0; }
-    # don't error if preserve is an empty array or even not set
-    preserve=$(echo "${factory_reset}" | jq -r '.preserve')
-    if [[ "null" != "${preserve}" && "[]" != "${preserve}" ]]; then
-        preserve=($(echo "${factory_reset}" | jq -e -r '.preserve | .[]')) || { handle_status "3" "-" "could_not_parse_preserve_array" ""; return 0; }
+    mode=$(echo "${factory_reset}" | jq -e -r '.mode') || { handle_status "1" "-" "mode not set" ""; return; }
+    preserve=$(echo "${factory_reset}" | jq -e -r '.preserve') || { handle_status "1" "-" "preserve object not set" ""; return; }
+    if [ "[]" != "${preserve}" ]; then
+        preserve=($(echo "${factory_reset}" | jq -e -r '.preserve | .[]')) || { handle_status "3" "-" "could_not_parse_preserve_array" ""; return; }
     else
         preserve=()
     fi
@@ -261,24 +268,24 @@ factory_reset_run() {
     preserve_list+=("/etc/omnect/factory-reset.d/")
     if [[ " ${preserve[@]} " =~ " applications " ]]; then
         preserve=( ${preserve[@]/applications} )
+        local preserve_path="";
         for i in $(find ${ROOTFS_DIR}/etc/omnect/factory-reset.d/ -iname *.json); do
-            preserve_list+=( $(cat ${i} | jq -r -e '.paths[]') )
-            preserve_list_err=$?
-            [[ 0 -ne ${preserve_list_err} ]] && { handle_status "3" "${preserve_list_err}" "${i/${ROOTFS_DIR}}:paths" "${preserve_list}"; factory_reset_umount; return 0; }
+            preserve_path=$(jq -r -e '.paths' ${i}) || { handle_status "3" "-" "${i/${ROOTFS_DIR}}: no path object" "${preserve_list}"; return; }
+            [[ "[]" != ${preserve_path} ]] && \
+                preserve_list+=( $(jq -r -e '.paths[]' ${i}) ) || { handle_status "3" "${?}" "${i/${ROOTFS_DIR}}: could parse paths array" "${preserve_list}"; return; }
         done
     fi
 
-    for key in ${preserve[@]}; do
-        preserve_list+=( $(cat ${ROOTFS_DIR}/etc/omnect/factory-reset.json | jq -r -e --arg key "${key}" .$key[]) )
-        preserve_list_err=$?
-        [[ 0 -ne ${preserve_list_err} ]] && { handle_status "3" "${preserve_list_err}" "${ROOTFS_DIR}/etc/omnect/factory-reset.json:${key}" "${preserve_list[@]}"; factory_reset_umount; return 0; }
+    for key in "${preserve[@]}"; do
+        preserve_list+=( $(jq -r -e --arg key "${key}" .$key[] ${ROOTFS_DIR}/etc/omnect/factory-reset.json) ) || \
+            { handle_status "3" "${?}" "${ROOTFS_DIR}/etc/omnect/factory-reset.json:${key}" "${preserve_list[@]}"; return; }
     done
 
     msg "factor-reset preserve_list=${preserve_list[@]}"
 
     # do the backup
     run_cmd mkdir -p ${factory_reset_backup_dir}
-    iterate_restore_list 1 "${preserve_list[@]}" || { factory_reset_umount; return 0; }
+    iterate_restore_list 1 "${preserve_list[@]}" || return;
     factory_reset_umount
 
     # possibly wipe


### PR DESCRIPTION
- preserve array is now mandatory
- post hook to unmount filesystems so the factory-reset module doesn't interfere with the fsmount module