### PR TITLE
refactor(bootloader): bootloader_versioning.bbclass improvements

### DIFF
--- a/classes/omnect_bootloader_versioning.bbclass
+++ b/classes/omnect_bootloader_versioning.bbclass
@@ -13,7 +13,6 @@
 #   corresponding sha256 checksums
 #
 # This class uses the following environment variables:
-# - `OMNECT_BOOTLOADER` - package name (PN) of used bootloader
 # - `OMNECT_BOOTLOADER_CHECKSUM_FILES` - list of input files (full path),
 #   wildcards are allowed
 # - `OMNECT_BOOTLOADER_CHECKSUM_FILES_GLOB_IGNORE` - list of files removed from
@@ -26,6 +25,7 @@
 #   content is different from the computed checksum, the build will fail
 #   note: if `OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE` is set, this var should be
 #         set to <old checksum>
+# - `OMNECT_BOOTLOADER_RECIPE_PATH` - path of bootloader recipe (mandatory)
 # - `OMNECT_BOOTLOADER_VERSION_CHECK_DISABLE` - disable fatal error when version
 #   check fails. (still produces an error.)
 
@@ -38,14 +38,14 @@ python() {
     import os
     from pathlib import Path
 
-    package_name = d.getVar("PN")
-    bootloader_name = d.getVar("OMNECT_BOOTLOADER")
-    if not bootloader_name:
-        bb.fatal("OMNECT_BOOTLOADER not set")
+    file = d.getVar("FILE")
+    bootloader_file = d.getVar("OMNECT_BOOTLOADER_RECIPE_PATH")
+    if not bootloader_file:
+        bb.fatal("OMNECT_BOOTLOADER_RECIPE_PATH not set")
 
     # since this runs at parse time, we have to ignore parsing of grub-efi for
-    # u-boot devices and vice versa
-    if package_name != bootloader_name:
+    # u-boot devices and vice versa, or recipes with the same PN and PV
+    if file != bootloader_file:
         return 0
 
     checksum_files = d.getVar("OMNECT_BOOTLOADER_CHECKSUM_FILES").split(" ")

--- a/conf/machine/genericx86-64.extra.conf
+++ b/conf/machine/genericx86-64.extra.conf
@@ -68,7 +68,7 @@ MACHINE_EXTRA_RRECOMMENDS:remove = "linux-firmware"
 SYSTEMD_RuntimeWatchdogSec  = "60"
 SYSTEMD_RebootWatchdogSec   = "60"
 
-OMNECT_BOOTLOADER="grub-efi"
+OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/grub/grub-efi_2.06.bb"
 # force bootloader version checksum to be old, when sure it's 100% binary compatible
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-grub-efi = "<newchecksum> <oldchecksum>"
 # e.g.:

--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -74,7 +74,7 @@ MACHINE_FEATURES:remove = " \
     optee \
 "
 
-OMNECT_BOOTLOADER = "u-boot-imx"
+OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-imx_2022.04_2.2.2-phy7.bb"
 # force bootloader version checksum to be old, when sure it's 100% binary compatible
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-u-boot-imx = "<newchecksum> <oldchecksum>"
 # e.g.:

--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -31,7 +31,7 @@ MACHINEOVERRIDES:prepend = "omnect_uboot:"
 # optional tpm2 support
 MACHINE_FEATURES += "tpm2"
 
-OMNECT_BOOTLOADER="u-boot"
+OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/u-boot/u-boot_2022.01.bb"
 # force bootloader version checksum to be old, when sure it's 100% binary compatible
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-u-boot = "<newchecksum> <oldchecksum>"
 # e.g.:

--- a/doc/Variables_Glossary.md
+++ b/doc/Variables_Glossary.md
@@ -63,6 +63,9 @@ See https://github.com/omnect/meta-omnect/blob/main/classes/omnect_uboot_embedde
 # OMNECT_BOOTLOADER_EMBEDDED_VERSION_UUUTAG
 See https://github.com/omnect/meta-omnect/blob/main/classes/omnect_uboot_embedded_version.bbclass.
 
+# OMNECT_BOOTLOADER_RECIPE_PATH
+See https://github.com/omnect/meta-omnect/blob/main/classes/omnect_bootloader_versioning.bbclass.
+
 # OMNECT_BOOTLOADER_VERSION_CHECK_DISABLE
 See https://github.com/omnect/meta-omnect/blob/main/classes/omnect_bootloader_versioning.bbclass.
 


### PR DESCRIPTION
bootloader_versioning.bbclass now explicitly uses `OMNECT_BOOTLOADER_RECIPE_PATH`
to prevent collisions when computing `OMNECT_BOOTLOADER_CHECKSUM`