### PR TITLE
refactor(omnect-os-image): revisited dependencies to python and compression libs

### DIFF
--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -110,15 +110,27 @@ SYSTEMD_SERVICE:remove:pn-busybox-syslog = "file://busybox-syslog.service"
 # restrict bluez5 dependencies
 PACKAGECONFIG:pn-bluez5 ?= "${@bb.utils.contains('OMNECT_RELEASE_IMAGE', '1', 'systemd udev', 'systemd udev deprecated readline tools', d)}"
 
+# restrict boost dependencies
+PACKAGECONFIG:pn-boost ?= ""
+
 # restrict docker-moby dependencies
 PACKAGECONFIG:pn-docker-moby ?= "seccomp"
 
 # restrict jq dependencies
 PACKAGECONFIG:pn-jq = ""
 
+# restrict opkg-utils dependency (can't use ?=)
+PACKAGECONFIG:pn-opkg-utils = "update-alternatives"
+
 # get rid of perl as runtime dependency in release image
 PACKAGES:remove:pn-nss = "nss-smime"
 PACKAGES:remove:pn-openssl = "openssl-misc"
+
+# restrict dependencies to python
+# we can't get rid of python though due to
+# gobject-introspection dependency in avahi + polkit
+CODEGEN_PYTHON_RDEPENDS:pn-glib-2.0 = ""
+RDEPENDS:${PN}:pn-gobject-introspection = ""
 
 # define default devel tools to be included in image
 OMNECT_DEVEL_TOOLS = "\

--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -112,12 +112,17 @@ PACKAGECONFIG:pn-bluez5 ?= "${@bb.utils.contains('OMNECT_RELEASE_IMAGE', '1', 's
 
 # restrict boost dependencies
 PACKAGECONFIG:pn-boost ?= ""
+DEPENDS:remove:pn-boot = "bzip2"
+BJAM_OPTS:append:class-target = ' -sNO_BZIP2=1'
 
 # restrict docker-moby dependencies
 PACKAGECONFIG:pn-docker-moby ?= "seccomp"
 
 # restrict jq dependencies
 PACKAGECONFIG:pn-jq = ""
+
+# restrict libarchive dependencies
+PACKAGECONFIG:pn-libarchive ?= "zlib xz ${@bb.utils.filter('DISTRO_FEATURES', 'acl xattr', d)}"
 
 # restrict opkg-utils dependency (can't use ?=)
 PACKAGECONFIG:pn-opkg-utils = "update-alternatives"

--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -112,7 +112,7 @@ PACKAGECONFIG:pn-bluez5 ?= "${@bb.utils.contains('OMNECT_RELEASE_IMAGE', '1', 's
 
 # restrict boost dependencies
 PACKAGECONFIG:pn-boost ?= ""
-DEPENDS:remove:pn-boot = "bzip2"
+DEPENDS:remove:pn-boost = "bzip2"
 BJAM_OPTS:append:class-target = ' -sNO_BZIP2=1'
 
 # restrict docker-moby dependencies


### PR DESCRIPTION
- got rid of image dependencies to bzip2, lzo, zstd
- restricted dependencies to python3. 

We can't get rid of python3, because it is a build dependency of libxml2 and gobject-introspection. We don't use gobject-introspection and don't have it set in `DISTRO_FEATURES`, but avahi und polkit depend on it anyway.