### PR TITLE
chore: update to yocto 4.0.23

### DIFF
--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.0"
-    # tag yocto-4.0.22
-    commit: "eb5c1ce6b1b8f33535ff7b9263ec7648044163ea"
+    # tag yocto-4.0.23
+    commit: "fb73c495c45d1d4107cfd60b67a5b4f11a99647b"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "kirkstone"
-    # tag yocto-4.0.22
-    commit: "f09fca692f96c9c428e89c5ef53fbcb92ac0c9bf"
+    # tag yocto-4.0.23
+    commit: "fb45c5cf8c2b663af293acb069d446610f77ff1a"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "4.0.22"
+  OE_VERSION: "4.0.23"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -25,7 +25,7 @@ repos:
   ext/meta-security:
     url: "https://git.yoctoproject.org/meta-security"
     branch: "kirkstone"
-    commit: "353078bc06c8b471736daab6ed193e30d533d1f1"
+    commit: "b9cf9cd639bc8d1b4828eb0bd012b71486d35176"
     layers:
       meta-tpm:
   ext/meta-swupdate:
@@ -35,7 +35,7 @@ repos:
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "kirkstone"
-    commit: "02a6c00d9370992a54296633de26a13a9a08ca2a"
+    commit: "c996df33763f292da5e7513c574272d7de23eafc"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "kirkstone"
-    commit: "54a6cce191886cb97c259ebdd344e05cbadd3e8f"
+    commit: "8ec6082d4652024d4b74bcb4e2f6c39075a71f12"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,8 +7,8 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: kirkstone
-    # yocto 4.0.22 (no tag)
-    commit: "ca60023fd70c4d6ecb9b3f57e4e4e3a3df13862b"
+    # yocto 4.0.23 (no tag)
+    commit: "20a38f21b26408d8b2598f0709ebc9cdcf1d05e2"
     layers:
       meta-yocto-bsp:
 


### PR DESCRIPTION
- updated openembedded-core + bitbake to yocto-4.0.23
- updated meta-security to latest kirkstone head
- updated meta-virtualization to latest kirkstone head
- updated meta-phytec to latest kirkstone head
- updated meta-yocto repo to latest kirkstone head