### PR TITLE
fix(omnect-device-service): error to update ssh ca

### DIFF
--- a/recipes-omnect/omnect-device-service/omnect-device-service/omnect-device-service.tmpfilesd
+++ b/recipes-omnect/omnect-device-service/omnect-device-service/omnect-device-service.tmpfilesd
@@ -1,6 +1,6 @@
 # /run/omnect-device-service gets created by omnect-os-initramfs
 d /run/omnect-device-service/ssh-tunnel 0700 ssh_tunnel_user ssh_tunnel_user 1h -
+Z /mnt/cert/ssh/*                       0644 ssh_tunnel_user ssh_tunnel_user -  -
 z /mnt/cert/ssh                         0755 ssh_tunnel_user ssh_tunnel_user -  -
-z /mnt/cert/ssh/*                       0644 ssh_tunnel_user ssh_tunnel_user -  -
 # create healthcheck log directory with desired permissions
 d /run/omnect_health_log 0775 root root -


### PR DESCRIPTION
This resolves an issue with the systemd-tmpfilesd config. With the current config, systemd-tmpfilesd would update the files in the wrong order and then refuse to adjust the ca file owner. Instead, we first adjust the owner recursively, and then adjust the file permissions after that.