### PR TITLE
fix: missing ssh cert dir

### DIFF
--- a/recipes-omnect/omnect-device-service/omnect-device-service/omnect-device-service.tmpfilesd
+++ b/recipes-omnect/omnect-device-service/omnect-device-service/omnect-device-service.tmpfilesd
@@ -1,6 +1,6 @@
 # /run/omnect-device-service gets created by omnect-os-initramfs
 d /run/omnect-device-service/ssh-tunnel 0700 ssh_tunnel_user ssh_tunnel_user 1h -
+d /mnt/cert/ssh                         0755 ssh_tunnel_user ssh_tunnel_user -  -
 Z /mnt/cert/ssh/*                       0644 ssh_tunnel_user ssh_tunnel_user -  -
-z /mnt/cert/ssh                         0755 ssh_tunnel_user ssh_tunnel_user -  -
 # create healthcheck log directory with desired permissions
 d /run/omnect_health_log 0775 root root -


### PR DESCRIPTION
When the ssh cert directory is non-existant, e.g., when the cert was not injected at image creation, the omnect-device-service fails to set the device certificate. Adjust the tempfilesd rule so that the directory is created with the correct permissions.