### PR TITLE
chore: update to yocto 4.0.24

### DIFF
--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.0"
-    # tag yocto-4.0.23
-    commit: "fb73c495c45d1d4107cfd60b67a5b4f11a99647b"
+    # tag yocto-4.0.24
+    commit: "3f88b005244a0afb5d5c7260e54a94a453ec9b3e"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "kirkstone"
-    # tag yocto-4.0.23
-    commit: "fb45c5cf8c2b663af293acb069d446610f77ff1a"
+    # tag yocto-4.0.24
+    commit: "a270d4c957259761bcc7382fcc54642a02f9fc7d"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "4.0.23"
+  OE_VERSION: "4.0.24"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -35,7 +35,7 @@ repos:
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "kirkstone"
-    commit: "76f2999987fa3ea30a823de3bd79d0cc0e0c287f"
+    commit: "c996df33763f292da5e7513c574272d7de23eafc"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -10,7 +10,7 @@ repos:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "kirkstone"
-    commit: "4ad41baed6236d499804cbfc4f174042d84fce97"
+    commit: "de8681b4a2a101b99dd2c48d89a7de2ccd9a961f"
     layers:
       meta-filesystems:
       meta-networking:
@@ -35,7 +35,7 @@ repos:
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "kirkstone"
-    commit: "c996df33763f292da5e7513c574272d7de23eafc"
+    commit: "76f2999987fa3ea30a823de3bd79d0cc0e0c287f"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "kirkstone"
-    commit: "8ec6082d4652024d4b74bcb4e2f6c39075a71f12"
+    commit: "27918633e0ed2aa6497ea00527d9ce7f458ed975"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,8 +7,8 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: kirkstone
-    # yocto 4.0.23 (no tag)
-    commit: "20a38f21b26408d8b2598f0709ebc9cdcf1d05e2"
+    # yocto 4.0.24 (no tag)
+    commit: "6e8a5bac75ca114ef2b4d3ca150b3f501519ea8f"
     layers:
       meta-yocto-bsp:
 


### PR DESCRIPTION
- updated openembedded-core + bitbake to yocto-4.0.24
- updated meta-openembedded to latest kirkstone head
- updated meta-phytec to latest kirkstone head
- updated meta-yocto repo to latest kirkstone head