### PR TITLE
feat(polkit): use smaller and faster javascript engine duktape vs mozjs

### DIFF
--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -131,6 +131,10 @@ PACKAGECONFIG:pn-opkg-utils = "update-alternatives"
 PACKAGES:remove:pn-nss = "nss-smime"
 PACKAGES:remove:pn-openssl = "openssl-misc"
 
+# use smaller and faster duktape vs mozjs in polkit
+PACKAGECONFIG:remove:pn-polkit = "mozjs"
+PACKAGECONFIG:append:pn-polkit = " duktape"
+
 # restrict dependencies to python
 # we can't get rid of python though due to
 # gobject-introspection dependency in avahi + polkit


### PR DESCRIPTION
Note: we use a limited polkit rule set, there are limitations when using
duktape: https://git.openembedded.org/meta-openembedded/tree/meta-oe/recipes-extended/polkit/polkit_124.bb?h=scarthgap#n33