### PR TITLE
chore: update to yocto 5.0.7

### DIFF
--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.8"
-    # tag yocto-5.0.6
-    commit: "f40a3a477d5241b697bf2fb030dd804c1ff5839f"
+    # tag yocto-5.0.7
+    commit: "aa0e540fc31a1c26839efd2c7785a751ce24ebfb"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "scarthgap"
-    # tag yocto-5.0.6
-    commit: "336eec6808710f260a5336ca8ca98139a80ccb14"
+    # tag yocto-5.0.7
+    commit: "62cb12967391db709315820d48853ffa4c6b4740"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "5.0.6"
+  OE_VERSION: "5.0.7"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -10,7 +10,7 @@ repos:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "dda0d53326017d6758ec6bdfdaf2f484c089d13f"
+    commit: "4f11a12b2352bbdfafb6b7d956bf424af4992977"
     layers:
       # meta-multimedia is used by qemu_8.2.2.imx.bb (tauri) ToDo: possible to handle that in the machine specific kas file?
       meta-multimedia:

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -15,7 +15,7 @@ repos:
   ext/meta-freescale:
     url: "https://github.com/Freescale/meta-freescale.git"
     branch: "scarthgap"
-    commit: "bdc5d81893b30a811d9c5af37470868689840623"
+    commit: "36accb283e2047cf52f3bc1857edad8507e049ec"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: scarthgap
-    commit: "bd166d1fb8dc1bed7e71bd06b970a3da9149203e"
+    commit: "03c7935bcdb15fd903d26828085d49c00267b8d9"
     layers:
       meta-yocto-bsp:
 


### PR DESCRIPTION
- updated openembedded-core + bitbake to yocto-5.0.7
- updated meta-openembedded to latest scarthgap head
- updated meta-freescale to latest scarthgap head
- updated meta-yocto repo to latest head