### PR TITLE
chore: update to yocto 4.0.25

### DIFF
--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -74,7 +74,7 @@ MACHINE_FEATURES:remove = " \
     optee \
 "
 
-OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-imx_2022.04_2.2.2-phy7.bb"
+OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-imx_2022.04_2.2.2-phy8.bb"
 # force bootloader version checksum to be old, when sure it's 100% binary compatible
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "<newchecksum> <oldchecksum>"
 # e.g.:
@@ -84,4 +84,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-im
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
 OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "2452a662c9e5a1366b36250e498f66aeb78143c4a9d1340ba5a6a25aa0c4fa3d"
-OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "891ff1eeefc29264ccbbf755b2cb721cac0f5e4067e944e1535634195f2c4d78 2452a662c9e5a1366b36250e498f66aeb78143c4a9d1340ba5a6a25aa0c4fa3d"
+OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "2a87075ac7f581724dfdd026177de1a3092ccc6ba93f65b9df118a166600f9ca 2452a662c9e5a1366b36250e498f66aeb78143c4a9d1340ba5a6a25aa0c4fa3d"

--- a/dynamic-layers/phytec/recipes-bsp/u-boot/u-boot/omnect_env.patch
+++ b/dynamic-layers/phytec/recipes-bsp/u-boot/u-boot/omnect_env.patch
@@ -1,18 +1,19 @@
 diff --git a/include/configs/phycore_imx8mm.h b/include/configs/phycore_imx8mm.h
-index 177b6278..b44bf1d0 100644
+index f9eabc8a822..04b4d37ecf9 100644
 --- a/include/configs/phycore_imx8mm.h
 +++ b/include/configs/phycore_imx8mm.h
-@@ -11,8 +11,7 @@
+@@ -11,8 +11,8 @@
  #include <linux/stringify.h>
  #include <asm/arch/imx-regs.h>
  
 -#include "phycore_rauc_env.h"
 -#include "phycore_fitimage_env.h"
 +#include <configs/omnect_env.h>
++
  
  #define CONFIG_SYS_BOOTM_LEN		SZ_64M
  #define CONFIG_SPL_MAX_SIZE		0x26000
-@@ -33,119 +32,6 @@
+@@ -33,120 +33,6 @@
  #define CONFIG_SPL_ABORT_ON_RAW_IMAGE
  #endif
  
@@ -127,11 +128,12 @@ index 177b6278..b44bf1d0 100644
 -
 -#ifdef CONFIG_ENV_WRITEABLE_LIST
 -/* Set environment flag validation to a list of env vars that must be writable */
--#define CONFIG_ENV_FLAGS_LIST_STATIC RAUC_REQUIRED_WRITABLE_ENV_FLAGS",dofitboot:dw"
+-#define CONFIG_ENV_FLAGS_LIST_STATIC RAUC_REQUIRED_WRITABLE_ENV_FLAGS",dofitboot:dw,mcore_clk:sw"
 -#endif
- 
+-
  /* Link Definitions */
  
+ #define CONFIG_SYS_INIT_RAM_ADDR	0x40000000
 @@ -179,4 +65,26 @@
  #define CONFIG_USB_MAX_CONTROLLER_COUNT	2
  #define CONFIG_SERIAL_TAG

--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.0"
-    # tag yocto-4.0.24
-    commit: "3f88b005244a0afb5d5c7260e54a94a453ec9b3e"
+    # tag yocto-4.0.25
+    commit: "e71f1ce53cf3b8320caa481ae62d1ce2900c4670"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "kirkstone"
-    # tag yocto-4.0.24
-    commit: "a270d4c957259761bcc7382fcc54642a02f9fc7d"
+    # tag yocto-4.0.25
+    commit: "5a794fd244f7fdeb426bd5e3def6b4effc0e8c62"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "4.0.24"
+  OE_VERSION: "4.0.25"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -31,11 +31,11 @@ repos:
   ext/meta-swupdate:
     url: "https://github.com/sbabic/meta-swupdate.git"
     branch: "kirkstone"
-    commit: "6918be849ddf1fed5b7a0173e51c7a136e8d4101"
+    commit: "b43bb01bbdfe8b7be3e9d4521e5871766db39ba3"
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "kirkstone"
-    commit: "c996df33763f292da5e7513c574272d7de23eafc"
+    commit: "b5a1645250c17fb657b7f10166f1c665ce192aaf"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "kirkstone"
-    commit: "27918633e0ed2aa6497ea00527d9ce7f458ed975"
+    commit: "da6456bbe2fb514c6efdfb2326fd16b12dbb3f8e"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,8 +7,8 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: kirkstone
-    # yocto 4.0.24 (no tag)
-    commit: "6e8a5bac75ca114ef2b4d3ca150b3f501519ea8f"
+    # yocto 4.0.25 (no tag)
+    commit: "2999fecd926976a1ea517c14e5dee996649dc80a"
     layers:
       meta-yocto-bsp:
 


### PR DESCRIPTION
- updated openembedded-core + bitbake to yocto-4.0.25
- updated meta-swupdate to latest kirkstone head
- updated meta-virtualization to latest kirkstone head
- updated meta-phytec to latest kirkstone head
- updated meta-yocto repo to latest kirkstone head