### PR TITLE
fix(omnect-os-initramfs.json): fixed fsck state when multiple partitions were fixed by fsck

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ The overall `factory reset status` consists of:
 
 ### Filesystem ckeck
 
-The `boot`, `cert`, `etc` and `data` Partition get checked non-interactively at boot via `fsck`. All questions of `fsck` regarding repairing the filesystem are answered with `yes`. The result of this process is returned as part of `/run/omnect-device-service/omnect-os-initramfs.json` via json object `fsck`.<br>
+The `boot`, `cert`, `etc` and `data` partition get checked non-interactively at boot via `fsck`. All questions of `fsck` regarding repairing the filesystem are answered with `yes`. The result of this process is returned as part of `/run/omnect-device-service/omnect-os-initramfs.json` via json object `fsck`.<br>
 If the object is empty, there were no filesystem issues. If the filesystem check encounters an error for a partition, the output of `fsck` for this parition is stored as json object named after the partition, e.g. if we encountered an error checking the `boot` partition the resulting `omnect-os-initramfs.json` has an entry `fsck.boot`.:
 
 ```json

--- a/README.md
+++ b/README.md
@@ -433,6 +433,28 @@ The overall `factory reset status` consists of:
 - optional: `context` on warnings or errors
 - array `paths` of preserved files or directories; this array reflects the configured paths not the actual restored path, e.g. if a path doesn't exist
 
+### Filesystem ckeck
+
+The `boot`, `cert`, `etc` and `data` Partition get checked non-interactively at boot via `fsck`. All questions of `fsck` regarding repairing the filesystem are answered with `yes`. The result of this process is returned as part of `/run/omnect-device-service/omnect-os-initramfs.json` via json object `fsck`.<br>
+If the object is empty, there were no filesystem issues. If the filesystem check encounters an error for a partition, the output of `fsck` for this parition is stored as json object named after the partition, e.g. if we encountered an error checking the `boot` partition the resulting `omnect-os-initramfs.json` has an entry `fsck.boot`.:
+
+```json
+{
+
+  "fsck": {
+
+    "boot": "fsck from util-linux 2.37.4\nfsck.fat 4.2 (2021-01-31)\nDirty bit is set. Fs was not properly unmounted and some data may be corrupt.\n Automatically removing dirty bit.\n\n*** Filesystem was changed ***\nWriting changes.\n/dev/mmcblk0p1: 75 files, 11264/20431 clusters"
+
+  },
+
+  "factory-reset": {}
+
+}
+
+```
+
+
+
 ### Debug Mount Options of Data Partition
 
 The filesystem inside the data partition is mounted using the mount options `defaults,noatime,nodiratime,async,rw`, per default.

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/common-sh
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/common-sh
@@ -63,14 +63,19 @@ check_fs()
     msg "check_fs /dev/omnect/${label}"
     echo "on" > /proc/sys/kernel/printk_devkmsg
 
-    # regular boot; fsck handles unclean state (i.e.; not unmounted)
-    fsck -y /dev/omnect/${label} &> /tmp/fsck_out
+    # in case of EFI the boot partition gets checked multiple times
+    if [ -f /tmp/fsck_out.${label} ]; then
+        msg "already run fsck for \"${label}\""
+        return 0
+    fi
+
+    fsck -y /dev/omnect/${label} &> /tmp/fsck_out.${label}
     fsck_res=$?
     msg "fsck result for \"${label}\" is ${fsck_res}"
-    msg "$(</tmp/fsck_out)"
+    msg "$(</tmp/fsck_out.${label})"
 
     if [ ${fsck_res} -ne 0 ]; then
-        save_fsck_status "${label}" "/tmp/fsck_out" "${fsck_res}"
+        save_fsck_status "${label}" "/tmp/fsck_out.${label}" "${fsck_res}"
         msg_error "command \"fsck -y /dev/omnect/${label}\" failed: ${fsck_res}"
     fi
 

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/omnect-device-service-setup
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/omnect-device-service-setup
@@ -26,10 +26,6 @@ get_id() {
 
 fsck_handling() {
     local labels=("boot" "cert" "data" "etc")
-    msg omnect_fsck_boot=$(get_bootloader_env_var "omnect_fsck_boot")
-    msg omnect_fsck_cert=$(get_bootloader_env_var "omnect_fsck_cert")
-    msg omnect_fsck_data=$(get_bootloader_env_var "omnect_fsck_data")
-    msg omnect_fsck_etc=$(get_bootloader_env_var "omnect_fsck_etc")
 
     echo "{}" > /tmp/fsck.json
     for i in ${labels[@]}; do

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/omnect-device-service-setup
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/omnect-device-service-setup
@@ -35,9 +35,11 @@ fsck_handling() {
     for i in ${labels[@]}; do
         local content=$(get_fsck_status ${i})
         if [ -n "${content}" ]; then
-            jq --arg i "${i}" --arg content "${content}" '{($i): ($content)}' /tmp/fsck.json > /tmp/fsck.json.tmp || return 1
+            jq --arg i "${i}" --arg content "${content}" '. += {($i): ($content)}' /tmp/fsck.json > /tmp/fsck.json.tmp || { msg "omnect_fsck_${i} json handling error"; return 1; }
             mv /tmp/fsck.json.tmp /tmp/fsck.json
             set_bootloader_env_var omnect_fsck_${i} ""
+        else
+            msg "no omnect_fsck_${i} available"
         fi
     done
 

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/omnect-device-service-setup
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/omnect-device-service-setup
@@ -26,6 +26,10 @@ get_id() {
 
 fsck_handling() {
     local labels=("boot" "cert" "data" "etc")
+    msg omnect_fsck_boot=$(get_bootloader_env_var "omnect_fsck_boot")
+    msg omnect_fsck_cert=$(get_bootloader_env_var "omnect_fsck_cert")
+    msg omnect_fsck_data=$(get_bootloader_env_var "omnect_fsck_data")
+    msg omnect_fsck_etc=$(get_bootloader_env_var "omnect_fsck_etc")
 
     echo "{}" > /tmp/fsck.json
     for i in ${labels[@]}; do


### PR DESCRIPTION
- fixed fsck state when multiple partitions were fixed by fsck
- also fixed problem with EFI fsck handling for boot partition
- added documentation for filesystem checks