### PR TITLE
chore(rpi): update to latest meta-raspberrypi scarthgap head

### DIFF
--- a/kas/machine/rpi/rpi.yaml
+++ b/kas/machine/rpi/rpi.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-raspberrypi:
     url: "https://github.com/agherzan/meta-raspberrypi.git"
     branch: "scarthgap"
-    commit: "6df7e028a2b7b2d8cab0745dc0ed2eebc3742a17"
+    commit: "e124d8284c8d9d8cda99a9fde3c12f550ca1d6c5"
     patches:
       p001:
         repo: "meta-omnect"


### PR DESCRIPTION
- updates kernel to 6.6.63 