### PR TITLE
fix(genericx86): improve boot robustness

### DIFF
--- a/conf/machine/genericx86-64.extra.conf
+++ b/conf/machine/genericx86-64.extra.conf
@@ -86,5 +86,5 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/grub/grub-efi_2.06
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-bootloader-versioned - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "c8d9ee35f35584b67fe734b59b5ca6e36d8ea4ba283128006977da77b17672de"
-OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "56daecd4f6cedf0cbbf4c9f622850450f7f601febf276199ba1f94e8fcc72d30 c8d9ee35f35584b67fe734b59b5ca6e36d8ea4ba283128006977da77b17672de"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "707f10b656550a4ef294ec0182f162e024d7dde17fd088bf3832ade61194a76a"
+#OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = ""

--- a/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/recipes-bsp/grub/grub-efi_%.bbappend
@@ -1,3 +1,5 @@
 PROVIDES:omnect_grub = "virtual/bootloader"
 
 inherit omnect_bootloader
+
+GRUB_BUILDIN:append = " echo"

--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
@@ -28,12 +28,14 @@ function set () {
     local key=${1}
     local value=${@:2}
     grub-editenv ${grubenv} set "${key}"="${value}"
+    sync
 }
 
 function unset() {
     [[ ${argsc} -ne 2 ]] && help && exit 1
     local key=${1}
     grub-editenv ${grubenv} unset "${key}"
+    sync
 }
 
 [[ ${#} -lt 1 ]] && help && exit 1

--- a/recipes-omnect/grub-cfg/grub-cfg/grub.cfg.in
+++ b/recipes-omnect/grub-cfg/grub-cfg/grub.cfg.in
@@ -9,16 +9,16 @@ fi
 
 if [ "x${omnect_validate_update}" = "x" ]; then
   if [ "x${omnect_validate_update_part}" = "x" ]; then
-    echo 'Normal boot - booting from partition ${omnect_os_bootpart}'
+    echo "Normal boot - booting from partition ${omnect_os_bootpart}"
   else
-    echo 'Update in progress - booting from partition ${omnect_validate_update_part}'
+    echo "Update in progress - booting from partition ${omnect_validate_update_part}"
     set omnect_validate_update=1
     save_env omnect_validate_update
     set omnect_os_bootpart=${omnect_validate_update_part}
     # no save_env omnect_os_bootpart here!
   fi
 else
-  echo 'Update validation failed - booting from partition ${omnect_os_bootpart}'
+  echo "Update validation failed - booting from partition ${omnect_os_bootpart}"
   set omnect_validate_update_part=
   save_env omnect_validate_update_part
   set omnect_validate_update=

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/grub-sh
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/grub-sh
@@ -35,6 +35,7 @@ set_bootloader_env_var()
     else
         grub-editenv ${ROOTFS_DIR}/boot/EFI/BOOT/grubenv unset "${var_name}" || return 1
     fi
+    sync
 }
 
 save_fsck_status()


### PR DESCRIPTION
CI/CD tests showed that intentionally crashing the system or causing a power cut can cause the system to get stuck in initramfs due to an empty grub environment file.
Therefore ensure that whenever the grub environment gets touched the change is made persistent via a subsequent sync.

Additionally enable grub echo module so that console output during boot works.