### PR TITLE
chore: update to yocto 4.0.26

### DIFF
--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -43,4 +43,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/u-boot/u-boot_2022
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-bootloader-versioned - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "a2f53a2dac5da8bd251b6d488983a3d94a11103f54f85eb4fa82ab050172b15b"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "7bbfd67e19a2f0469ff5dbbbb455ec28f442b84fb171822345879069a8c10bdd"

--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.0"
-    # tag yocto-4.0.25
-    commit: "e71f1ce53cf3b8320caa481ae62d1ce2900c4670"
+    # tag yocto-4.0.26
+    commit: "046871d9fd76efdca7b72718b328d8f545523f7e"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "kirkstone"
-    # tag yocto-4.0.25
-    commit: "5a794fd244f7fdeb426bd5e3def6b4effc0e8c62"
+    # tag yocto-4.0.26
+    commit: "1efbe1004bc82e7c14c1e8bd4ce644f5015c3346"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "4.0.25"
+  OE_VERSION: "4.0.26"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -10,7 +10,7 @@ repos:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "kirkstone"
-    commit: "de8681b4a2a101b99dd2c48d89a7de2ccd9a961f"
+    commit: "f8dddbfcbfe502cb71375a7a907e61a92e8d4474"
     layers:
       meta-filesystems:
       meta-networking:
@@ -35,7 +35,7 @@ repos:
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "kirkstone"
-    commit: "b5a1645250c17fb657b7f10166f1c665ce192aaf"
+    commit: "227cefa1261daf20b7d9737541994ec2bba629fc"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "kirkstone"
-    commit: "da6456bbe2fb514c6efdfb2326fd16b12dbb3f8e"
+    commit: "32f672dbeb24bdbcd0a53e1e15bd9c5f0d162d63"
     patches:
       p001:
         repo: "meta-omnect"
@@ -15,7 +15,7 @@ repos:
   ext/meta-freescale:
     url: "https://github.com/Freescale/meta-freescale.git"
     branch: "kirkstone"
-    commit: "c525e0c19bdc46d45f71873b5f286f49abb69418"
+    commit: "2f83b211beff98d84632b186691ca1ffda34fa6c"
     patches:
       p001:
         repo: "meta-omnect"
@@ -27,7 +27,7 @@ repos:
   ext/meta-imx:
     url: "https://github.com/nxp-imx/meta-imx.git"
     branch: "kirkstone-5.15.71-2.2.2"
-    commit: "ca68ab5d25322b51f54564275c84ab8de3c74ea6"
+    commit: "af4c67f25fff2dce54487ee5bfd618ab9789a8dc"
     layers:
       meta-bsp:
       meta-sdk:

--- a/kas/machine/rpi/rpi.yaml
+++ b/kas/machine/rpi/rpi.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-raspberrypi:
     url: "https://github.com/agherzan/meta-raspberrypi.git"
     branch: "kirkstone"
-    commit: "d7544f35756d87834e8b4bf3e3e733c771d380ae"
+    commit: "9e12ad97b4c95772c6f403b9318f2bec2ab09e53"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,8 +7,8 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: kirkstone
-    # yocto 4.0.25 (no tag)
-    commit: "2999fecd926976a1ea517c14e5dee996649dc80a"
+    # yocto 4.0.26 (no tag)
+    commit: "3dd438c749099f2a5e808c4690d7ea767263e5b5"
     layers:
       meta-yocto-bsp:
 


### PR DESCRIPTION
- updated openembedded-core + bitbake to yocto-4.0.26
- updated meta-openembedded to latest kirkstone head
- updated meta-virtualization to latest kirkstone head
- updated meta-phytec to latest kirkstone head
- updated meta-freescale to latest kirkstone head
- updated meta-imx to latest kirkstone-5.15.71-2.2.2 head
- updated meta-raspberrypi to latest kirkstone head
- updated meta-yocto repo to latest kirkstone head
- adapted `OMNECT_BOOTLOADER_CHECKSUM_EXPECTED` for raspberrypi since openembedded-core fixed multiple u-boot cve's

note: a bootloader update is enforced for raspberrypi