### PR TITLE
fix(NetworkManager): names of WWAN interfaces to be managed were too strictly defined

### DIFF
--- a/recipes-connectivity/networkmanager/files/NetworkManager.conf
+++ b/recipes-connectivity/networkmanager/files/NetworkManager.conf
@@ -13,4 +13,5 @@ hostname-mode=none
 autoconnect-retries-default=0
 
 [keyfile]
-unmanaged-devices=except:interface-name:wwan*,except:interface-name:cdc-wdm*
+# we assume that WWAN interface names start with ww or cdc-wdm
+unmanaged-devices=except:interface-name:ww*,except:interface-name:cdc-wdm*


### PR DESCRIPTION
Previous NetworkManager.conf defined the managed (LTE) interfaces to have names either prefixed with wwan or cdc-wdm.
However, in scarthgap such interfaces might have their topological name (specifying the position hardware-wise), e.g. `wwp0s21f0u8i4`.
In any case, interface names starting with `ww` are intended for WWAN interfaces like LTE modems (see man page for `systemd.net-naming-scheme(7)`), so use this prefix to determine WWAN interfaces to be managed by NetworkManager.