### PR TITLE
chore: update to yocto 5.0.10

### DIFF
--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -96,7 +96,7 @@ MACHINE_FEATURES:append = " \
     pstore \
 "
 
-OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy11.bb"
+OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy15.bb"
 
 # force bootloader version checksum to be old, when sure it's 100% binary compatible
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "<newchecksum> <oldchecksum>"
@@ -106,4 +106,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-ph
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-bootloader-versioned - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "8164561747f3b79197167f060816a0e168d8bc002fa97ae632cfc6b909a56c87"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "aabb383cafd6f082e0e5c2d7d4eec6f1c5daa10d3613e73d5c659d981be8401a"

--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -44,3 +44,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/u-boot/u-boot_2024
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
 OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "f9beee6e5ca031cf7cc37403ddd116c9737c172cdd554e5faced296e2d5375e5"
+OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "5df30fc7511f3bebec58662c4a1ca105c576d5d65245f0a10ab9284f391f56c0 f9beee6e5ca031cf7cc37403ddd116c9737c172cdd554e5faced296e2d5375e5"

--- a/dynamic-layers/raspberrypi/recipes-bsp/bootloader-versioned/bootloader-versioned.bbappend
+++ b/dynamic-layers/raspberrypi/recipes-bsp/bootloader-versioned/bootloader-versioned.bbappend
@@ -1,6 +1,7 @@
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_omnect}/dynamic-layers/raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend"
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_omnect}/dynamic-layers/raspberrypi/recipes-bsp/u-boot/u-boot/*"
-OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_raspberrypi}/recipes-bsp/u-boot/u-boot_%.bbappend"
+# the u-boot_%.bbappend from meta-raspberrypi is part of BBMASK and thus not part of OMNECT_BOOTLOADER_CHECKSUM_FILES
+#OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_raspberrypi}/recipes-bsp/u-boot/u-boot_%.bbappend"
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_raspberrypi}/recipes-bsp/u-boot/files/*"
 # we have to update the raspberrypi firmware if basic configuration of the bsp changes
 # per convention such changes should be made in the following file:

--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.8"
-    # tag yocto-5.0.9
+    # tag yocto-5.0.10
     commit: "696c2c1ef095f8b11c7d2eff36fae50f58c62e5e"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "scarthgap"
-    # tag yocto-5.0.9
-    commit: "04038ecd1edd6592b826665a2b787387bb7074fa"
+    # tag yocto-5.0.10
+    commit: "d5342ffc570d47a723b18297d75bd2f63c2088db"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "5.0.9"
+  OE_VERSION: "5.0.10"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -10,7 +10,7 @@ repos:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "e92d0173a80ea7592c866618ef5293203c50544c"
+    commit: "491671faee11ea131feab5a3a451d1a01deb2ab1"
     layers:
       # meta-multimedia is used by qemu_8.2.2.imx.bb (tauri) ToDo: possible to handle that in the machine specific kas file?
       meta-multimedia:
@@ -34,7 +34,7 @@ repos:
   ext/meta-swupdate:
     url: "https://github.com/sbabic/meta-swupdate.git"
     branch: "scarthgap"
-    commit: "b5de0ce2ec42e7e58261d81ea66fbf1d51bdf2aa"
+    commit: "43ef322cbf5b91d84b007c343cf73e9b01699594"
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "scarthgap"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "scarthgap"
-    commit: "5c7c1e37068d5fdd6826796f7044cbd680ff2921"
+    commit: "a2067bfc5b4451259a09899c59e9078fa2ec480a"
     patches:
       p001:
         repo: "meta-omnect"
@@ -15,7 +15,7 @@ repos:
   ext/meta-freescale:
     url: "https://github.com/Freescale/meta-freescale.git"
     branch: "scarthgap"
-    commit: "f52fe2b709e70d1d864adfad2754213bce7abcd7"
+    commit: "a82f138b140f613a06bf9ac60101e4bb511c309f"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/rpi/rpi.yaml
+++ b/kas/machine/rpi/rpi.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-raspberrypi:
     url: "https://github.com/agherzan/meta-raspberrypi.git"
     branch: "scarthgap"
-    commit: "3b27c95c163a042f8056066ec3d27edfcc42da7f"
+    commit: "bce7b3acd2e0d9d127fcb57eae4a512bd7e7924a"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: scarthgap
-    commit: "7f1be5a930554ea5036d2c806aa752ae0b2de826"
+    commit: "7633f51d53f535728fe035fa866416d2e5ba6a9c"
     layers:
       meta-yocto-bsp:
 


### PR DESCRIPTION
- updated openembedded to yocto-5.0.10
- updated meta-openembedded to latest scarthgap head
- updated meta-swupdate to latest scarthgap head
- updated meta-phytec to latest scarthgap head
- updated meta-freescale to latest scarthgap head
- updated meta-raspberrypi to latest scarthgap head
- updated meta-yocto repo to latest scarthgap head

**note**: this update includes a bootloader update for phytec tauri-l  (https://github.com/phytec/meta-phytec/commit/a7c035bca24cde242d046ae4d91fe143d1181c15).
