### PR TITLE
fix(grub): refactored secure boot provisioning handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ This yocto meta layer provides the device management distribution `omnect-os`. I
     - First boot script `/usr/bin/omnect_first_boot.sh` which is executed at first boot of the device; it can be adapted via `meta-omnect/recipes-core/systemd/systemd/omnect_first_boot.sh`
     - Factory reset via OS bootloader environment variable `factory-reset`
       - **Note**: This feature provides a limited level of data privacy. Please see section [Factory Reset](#factory-reset) below.
+    - [Secure Boot for x86 UEFI devices](doc/efi_secure_boot.md).
 - `omnect-os update image`: the [`swupdate`](https://sbabic.github.io/swupdate/swupdate.html) update image with the following implicit features:
     - Updating the bootloader
 

--- a/conf/machine/genericx86-64.extra.conf
+++ b/conf/machine/genericx86-64.extra.conf
@@ -103,5 +103,5 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/grub/grub-efi_2.12
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-bootloader-versioned - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "2d3392047eb24e53826bcd8c1af3b02dd74971b2cfa7c2f3393f591546e77d8b"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "c570cdc6e640bea64ddcdb6428bbc71e2f178c5716a02bbbfe0b43d90d41875f"
 #OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = ""

--- a/doc/efi_secure_boot.md
+++ b/doc/efi_secure_boot.md
@@ -1,0 +1,24 @@
+# UEFI secure boot
+Currently we support secure boot only for x86 plattforms.
+
+## Certificate/Key Provisioning
+- Enable Secure Boot in UEFI (Bios).
+- Delete existing certificates in UEFI (Bios), e.g. "Erase all Secure Boot Settings". Note: If you "Reset Secure Boot to Factory" it may preset Microsoft certificates and thus prevents provisioning of omnect-os certificates.
+- Boot to omnect-os and enforce certificate provisioning via:
+    - `sudo mokutil --sbstate`<br>
+      expected result:
+      ```sh
+      SecureBoot disabled
+      Platform is in Setup Mode
+      ```
+    - `sudo bootloader_env.sh set omnect_force_sb_provision 1`
+    - `sudo reboot`
+
+    These steps result in a preselected grub menu entry "Certificate Provision". After executing this menu entry, grub will reboot afterwarts.
+- Enable Secure Boot in UEFI (BIOS).
+- Boot to omnect-os and verify the secure boot state via:
+    - `sudo mokutil --sbstate`<br>
+      expected result:
+      ```sh
+      SecureBoot enabled
+      ```

--- a/doc/efi_secure_boot.md
+++ b/doc/efi_secure_boot.md
@@ -1,5 +1,5 @@
 # UEFI secure boot
-Currently we support secure boot only for x86 plattforms.
+Currently we support secure boot only for x86 platforms.
 
 ## Certificate/Key Provisioning
 - Enable Secure Boot in UEFI (Bios).
@@ -15,7 +15,6 @@ Currently we support secure boot only for x86 plattforms.
     - `sudo reboot`
 
     These steps result in a preselected grub menu entry "Certificate Provision". After executing this menu entry, grub will reboot afterwarts.
-- Enable Secure Boot in UEFI (BIOS).
 - Boot to omnect-os and verify the secure boot state via:
     - `sudo mokutil --sbstate`<br>
       expected result:

--- a/doc/efi_secure_boot.md
+++ b/doc/efi_secure_boot.md
@@ -3,7 +3,7 @@ Currently we support secure boot only for x86 platforms.
 
 ## Certificate/Key Provisioning
 - Enable Secure Boot in UEFI (Bios).
-- Delete existing certificates in UEFI (Bios), e.g. "Erase all Secure Boot Settings". Note: If you "Reset Secure Boot to Factory" it may preset Microsoft certificates and thus prevents provisioning of omnect-os certificates.
+- Delete existing certificates in UEFI (Bios), e.g. "Erase all Secure Boot Settings". Note: If you "Reset Secure Boot to Factory" it may preset Microsoft certificates and thus prevent provisioning of omnect-os certificates.
 - Boot to omnect-os and enforce certificate provisioning via:
     - `sudo mokutil --sbstate`<br>
       expected result:
@@ -14,7 +14,7 @@ Currently we support secure boot only for x86 platforms.
     - `sudo bootloader_env.sh set omnect_force_sb_provision 1`
     - `sudo reboot`
 
-    These steps result in a preselected grub menu entry "Certificate Provision". After executing this menu entry, grub will reboot afterwarts.
+    These steps result in a preselected grub menu entry "Certificate Provision". After executing this menu entry, grub will reboot.
 - Boot to omnect-os and verify the secure boot state via:
     - `sudo mokutil --sbstate`<br>
       expected result:

--- a/recipes-bsp/grub/grub-efi/efi-secure-boot.inc
+++ b/recipes-bsp/grub/grub-efi/efi-secure-boot.inc
@@ -19,6 +19,7 @@ if [ "${omnect_force_sb_provision}" = "1" -a "${unprovisioned}" = "1" ]; then
 
         chainloader "${prefix}/LockDown.efi"
         boot
+        # Refuse to unlimitedly run into auto provision if failed.
         set provision_failed="1"
         save_env provision_failed
         set omnect_force_sb_provision="1"

--- a/recipes-bsp/grub/grub-efi/efi-secure-boot.inc
+++ b/recipes-bsp/grub/grub-efi/efi-secure-boot.inc
@@ -12,18 +12,18 @@ if [ "${omnect_force_sb_provision}" = "1" -a "${unprovisioned}" = "1" ]; then
     fi
 
     menuentry "Certificate Provision" --unrestricted {
-        set provision_failed="0"
+        unset provision_failed
         save_env provision_failed
-        set omnect_force_sb_provision="0"
+        unset omnect_force_sb_provision
         save_env omnect_force_sb_provision
 
         chainloader "${prefix}/LockDown.efi"
-
-        # Refuse to unlimitedly run into auto provision if failed.
+        boot
         set provision_failed="1"
         save_env provision_failed
         set omnect_force_sb_provision="1"
         save_env omnect_force_sb_provision
+        sleep 60
         reboot
     }
 fi

--- a/recipes-bsp/grub/grub-efi_%.bbappend
+++ b/recipes-bsp/grub/grub-efi_%.bbappend
@@ -19,4 +19,4 @@ do_compile:append:class-target() {
 
 }
 
-GRUB_BUILDIN:append = " echo"
+GRUB_BUILDIN:append = " echo sleep"


### PR DESCRIPTION
- grub: ensure LockDown.efi is booted
- doc: added documentation for secure boot certificate provisioning