### PR TITLE
chore: update to yocto 5.0.12

### DIFF
--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -96,7 +96,7 @@ MACHINE_FEATURES:append = " \
     pstore \
 "
 
-OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy21.bb"
+OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy22.bb"
 
 # force bootloader version checksum to be old, when sure it's 100% binary compatible
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "<newchecksum> <oldchecksum>"
@@ -107,4 +107,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-ph
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
 OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "5995f45fa9a864e9e9d226f3c40522f3e80a2ed42f7b086296b9ed14a9fa138a"
-#OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned= "ad08b27e6274141bfe09931eb1f635478f15027cee2e81eee86eebfdd2f62363 aabb383cafd6f082e0e5c2d7d4eec6f1c5daa10d3613e73d5c659d981be8401a"
+OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned= "a794d2558458350f3c6bf49e355984d5e12a71b2e1feab1e457abc23fd20f5cf 5995f45fa9a864e9e9d226f3c40522f3e80a2ed42f7b086296b9ed14a9fa138a"

--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.8"
-    # tag yocto-5.0.11
-    commit: "139f61fe9eec221745184a14b3618d2dfa650b91"
+    # tag yocto-5.0.12
+    commit: "982645110a19ebb94d519926a4e14c8a2a205cfd"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "scarthgap"
-    # tag yocto-5.0.11
-    commit: "7a59dc5ee6edd9596e87c2fbcd1f2594c06b3d1b"
+    # tag yocto-5.0.12
+    commit: "93c7489d843a0e46fe4fc685b356d0ae885300d7"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "5.0.11"
+  OE_VERSION: "5.0.12"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -10,7 +10,7 @@ repos:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "e8fd97d86af86cdcc5a6eb3f301cbaf6a2084943"
+    commit: "b9fb6556a3c8a3e477dce334205b658cb79ad501"
     layers:
       # meta-multimedia is used by qemu_8.2.2.imx.bb (tauri) ToDo: possible to handle that in the machine specific kas file?
       meta-multimedia:
@@ -38,7 +38,7 @@ repos:
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "scarthgap"
-    commit: "a5449c0c50aa07d02186f548fe6bb6c1ce8823dc"
+    commit: "af1db2042caf8021d767dce1b26c08b59b96f3d1"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "scarthgap"
-    commit: "567b4e631bb6ed1d068d90948cfef0af8a216c93"
+    commit: "9864fc05235f5d6a359559e4c86a37ee9f8dc319"
     patches:
       p001:
         repo: "meta-omnect"
@@ -15,7 +15,7 @@ repos:
   ext/meta-freescale:
     url: "https://github.com/Freescale/meta-freescale.git"
     branch: "scarthgap"
-    commit: "f460216d7239cd26d83ab9a0a419f6560c71b0c5"
+    commit: "212f4b3b175f6d58c691192545454cd2d2e908d9"
     patches:
       p001:
         repo: "meta-omnect"
@@ -34,7 +34,7 @@ repos:
   ext/meta-arm:
     url: "https://git.yoctoproject.org/meta-arm"
     branch: "scarthgap"
-    commit: "8e0f8af90fefb03f08cd2228cde7a89902a6b37c"
+    commit: "0f1e7bf92c89759f0ab74cfa5be4ee47b092ad46"
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/kas/machine/rpi/rpi.yaml
+++ b/kas/machine/rpi/rpi.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-raspberrypi:
     url: "https://github.com/agherzan/meta-raspberrypi.git"
     branch: "scarthgap"
-    commit: "3afc9728b1f4ba0f5be1af34883d6582966133a1"
+    commit: "aaf976a665daa7e520545908adef8a0e9410b57f"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,13 +7,13 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: scarthgap
-    commit: "50e5c0d85d3775ac1294bdcd7f11deaa382c9d08"
+    commit: "82602cda1a89644d1acbe230a81c93e3fb5031c8"
     layers:
       meta-yocto-bsp:
   ext/meta-secure-core:
     url: "https://github.com/Wind-River/meta-secure-core.git"
     branch: "scarthgap"
-    commit: "7a51f091cccfb8f629ce962f13b7b45d23005093"
+    commit: "eba66ba00566110d3bcdfe2fef47f81d4806012b"
     layers:
       meta-efi-secure-boot:
       meta-secure-core-common:
@@ -25,7 +25,7 @@ repos:
   ext/meta-perl:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "67ad83dd7c2485dae0c90eac345007af6195b84d"
+    commit: "b9fb6556a3c8a3e477dce334205b658cb79ad501"
     layers:
       meta-perl:
 


### PR DESCRIPTION
- updated openembedded-core and bitbake to yocto-5.0.12
- updated meta-openembedded to latest scarthgap head
- updated meta-virtualization to latest scarthgap head 
- updated meta-phytec to latest scarthgap head
- updated meta-freescale to latest scarthgap head
- updated meta-arm to latest scarthgap head
- updated meta-raspberrypi to latest scarthgap head
- updated meta-yocto repo to latest scarthgap head
- updated meta-secure-core to latest scarthgap head