### PR TITLE
chore: update to yocto 5.0.13

### DIFF
--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -96,7 +96,7 @@ MACHINE_FEATURES:append = " \
     pstore \
 "
 
-OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy22.bb"
+OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy23.bb"
 
 # force bootloader version checksum to be old, when sure it's 100% binary compatible
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "<newchecksum> <oldchecksum>"
@@ -106,5 +106,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-ph
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-bootloader-versioned - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "5995f45fa9a864e9e9d226f3c40522f3e80a2ed42f7b086296b9ed14a9fa138a"
-OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned= "a794d2558458350f3c6bf49e355984d5e12a71b2e1feab1e457abc23fd20f5cf 5995f45fa9a864e9e9d226f3c40522f3e80a2ed42f7b086296b9ed14a9fa138a"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "faa4ee371d68bc291465422c1e8713cd2b5e0954c7feb354b76217652c3b07df"

--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.8"
-    # tag yocto-5.0.12
-    commit: "982645110a19ebb94d519926a4e14c8a2a205cfd"
+    # tag yocto-5.0.13
+    commit: "1c9ec1ffde75809de34c10d3ec2b40d84d258cb4"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "scarthgap"
-    # tag yocto-5.0.12
-    commit: "93c7489d843a0e46fe4fc685b356d0ae885300d7"
+    # tag yocto-5.0.13
+    commit: "7af6b75221d5703ba5bf43c7cd9f1e7a2e0ed20b"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "5.0.12"
+  OE_VERSION: "5.0.13"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -10,7 +10,7 @@ repos:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "b9fb6556a3c8a3e477dce334205b658cb79ad501"
+    commit: "15e18246dd0c0585cd1515a0be8ee5e2016d1329"
     layers:
       # meta-multimedia is used by qemu_8.2.2.imx.bb (tauri) ToDo: possible to handle that in the machine specific kas file?
       meta-multimedia:

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "scarthgap"
-    commit: "9864fc05235f5d6a359559e4c86a37ee9f8dc319"
+    commit: "54425fe52f16c9aafab35278638055c07db402d1"
     patches:
       p001:
         repo: "meta-omnect"
@@ -15,7 +15,7 @@ repos:
   ext/meta-freescale:
     url: "https://github.com/Freescale/meta-freescale.git"
     branch: "scarthgap"
-    commit: "212f4b3b175f6d58c691192545454cd2d2e908d9"
+    commit: "7d83a350d8b28498321a481a2a1c51bb4afb48e9"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/rpi/rpi.yaml
+++ b/kas/machine/rpi/rpi.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-raspberrypi:
     url: "https://github.com/agherzan/meta-raspberrypi.git"
     branch: "scarthgap"
-    commit: "aaf976a665daa7e520545908adef8a0e9410b57f"
+    commit: "8767e2ff80ec3b09cd70dd22cdb18e783ab20d7b"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: scarthgap
-    commit: "82602cda1a89644d1acbe230a81c93e3fb5031c8"
+    commit: "3ff7ca786732390cd56ae92ff4a43aba46a1bf2e"
     layers:
       meta-yocto-bsp:
   ext/meta-secure-core:
@@ -25,7 +25,7 @@ repos:
   ext/meta-perl:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "b9fb6556a3c8a3e477dce334205b658cb79ad501"
+    commit: "15e18246dd0c0585cd1515a0be8ee5e2016d1329"
     layers:
       meta-perl:
 


### PR DESCRIPTION
- updated openembedded-core and bitbake to yocto-5.0.13
- updated meta-openembedded to latest scarthgap head
- updated meta-phytec to latest scarthgap head
- updated meta-freescale to latest scarthgap head
- updated meta-raspberrypi to latest scarthgap head
- updated meta-yocto repo to latest scarthgap head

**note**: phytec-imx8mm (tauri-l) bootloader gets updated