### PR TITLE
chore: update to yocto 5.0.14

### DIFF
--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -107,3 +107,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-ph
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
 OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "faa4ee371d68bc291465422c1e8713cd2b5e0954c7feb354b76217652c3b07df"
+OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "5c72bdd2b9bc83bde5744970bb113b290d415417e756caf4c41fdf12d83cc61a faa4ee371d68bc291465422c1e8713cd2b5e0954c7feb354b76217652c3b07df"

--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.8"
-    # tag yocto-5.0.13
-    commit: "1c9ec1ffde75809de34c10d3ec2b40d84d258cb4"
+    # tag yocto-5.0.14
+    commit: "8dcf084522b9c66a6639b5f117f554fde9b6b45a"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "scarthgap"
-    # tag yocto-5.0.13
-    commit: "7af6b75221d5703ba5bf43c7cd9f1e7a2e0ed20b"
+    # tag yocto-5.0.14
+    commit: "471adaa5f77fa3b974eab60a2ded48e360042828"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "5.0.13"
+  OE_VERSION: "5.0.14"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -10,7 +10,7 @@ repos:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "15e18246dd0c0585cd1515a0be8ee5e2016d1329"
+    commit: "7ed4330bcf1ecd4aa34bfbe1fd7079381b62b1e7"
     layers:
       # meta-multimedia is used by qemu_8.2.2.imx.bb (tauri) ToDo: possible to handle that in the machine specific kas file?
       meta-multimedia:
@@ -28,17 +28,17 @@ repos:
   ext/meta-security:
     url: "https://git.yoctoproject.org/meta-security"
     branch: "scarthgap"
-    commit: "bc865c5276c2ab4031229916e8d7c20148dfbac3"
+    commit: "afbbe28cee4af2c6760aaead43a4a3ef29969809"
     layers:
       meta-tpm:
   ext/meta-swupdate:
     url: "https://github.com/sbabic/meta-swupdate.git"
     branch: "scarthgap"
-    commit: "43ef322cbf5b91d84b007c343cf73e9b01699594"
+    commit: "2b48267fcfedf61c2a33c7830e794115263639f8"
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "scarthgap"
-    commit: "af1db2042caf8021d767dce1b26c08b59b96f3d1"
+    commit: "17ac21e7d7f6f40a87618b22278b63bcfa14dbf2"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "scarthgap"
-    commit: "54425fe52f16c9aafab35278638055c07db402d1"
+    commit: "f9d9ee9f5e74d1336757361bb91c9413250f19fc"
     patches:
       p001:
         repo: "meta-omnect"
@@ -23,7 +23,7 @@ repos:
   ext/meta-imx:
     url: "https://github.com/nxp-imx/meta-imx.git"
     branch: "scarthgap-6.6.52-2.2.1"
-    commit: "89c4d98c236ac1a2fbfcc92e5adf6571e41bd2da"
+    commit: "e83d4402acde050d2b2761995761c81c797b5b03"
     layers:
       meta-imx-bsp:
       meta-imx-sdk:
@@ -34,7 +34,7 @@ repos:
   ext/meta-arm:
     url: "https://git.yoctoproject.org/meta-arm"
     branch: "scarthgap"
-    commit: "0f1e7bf92c89759f0ab74cfa5be4ee47b092ad46"
+    commit: "a81c19915b5b9e71ed394032e9a50fd06919e1cd"
     layers:
       meta-arm:
       meta-arm-toolchain:

--- a/kas/machine/rpi/rpi.yaml
+++ b/kas/machine/rpi/rpi.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-raspberrypi:
     url: "https://github.com/agherzan/meta-raspberrypi.git"
     branch: "scarthgap"
-    commit: "8767e2ff80ec3b09cd70dd22cdb18e783ab20d7b"
+    commit: "cd677051d18d4af2f043ac1ab58509ae5f594cf6"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: scarthgap
-    commit: "3ff7ca786732390cd56ae92ff4a43aba46a1bf2e"
+    commit: "bf6aea52c4009e08f26565c33ce432eec7cfb090"
     layers:
       meta-yocto-bsp:
   ext/meta-secure-core:
@@ -25,7 +25,7 @@ repos:
   ext/meta-perl:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "15e18246dd0c0585cd1515a0be8ee5e2016d1329"
+    commit: "7ed4330bcf1ecd4aa34bfbe1fd7079381b62b1e7"
     layers:
       meta-perl:
 

--- a/recipes-extended/iptables/iptables_%.bbappend
+++ b/recipes-extended/iptables/iptables_%.bbappend
@@ -17,7 +17,4 @@ do_install:append() {
         -e 's#^ExecStart=\(.*\)$#ExecStart=/usr/sbin/ip6tables-nft-restore -- /etc/iptables/ip6tables.rules#' \
         -e 's#^ExecReload=\(.*\)$#ExecReload=/usr/sbin/ip6tables-nft-restore -- /etc/iptables/ip6tables.rules#' \
         ${D}${systemd_system_unitdir}/ip6tables.service
-
-    # /etc/ethertypes is already owned by netbase package which is a dependency of packagegroup-core-boot
-    rm ${D}${sysconfdir}/ethertypes
 }


### PR DESCRIPTION
- updated openembedded-core and bitbake to yocto-5.0.14
- updated meta-openembedded to latest scarthgap head
- updated meta-security to latest scarthgap head
- updated meta-swupdate to latest scarthgap head
- updated meta-virtualization to latest scarthgap head
- updated meta-phytec to latest scarthgap head
- updated meta-imx to latest scarthgap-6.6.52-2.2.1 head
- updated meta-arm to latest scarthgap head
- updated meta-raspberrypi to latest scarthgap head
- updated meta-yocto repo to latest scarthgap head
- iptables: adapted to upstream recipe changes