### PR TITLE
refactor: removed cramfs and added fstrim systemd service & timer files

### DIFF
--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -45,6 +45,7 @@ CONNECTIVITY_CHECK_URIS ?= "https://github.com/omnect"
 
 # Image configuration
 IMAGE_FSTYPES = "ext4.gz wic.xz wic.bmap"
+IMAGE_TYPES:remove = "cramfs"
 # rm kernel from boot partition, we use a bundled initramfs kernel in rootfs
 IMAGE_BOOT_FILES:remove = "uImage Image"
 # instead of kernel we want the initramfs bundled kernel

--- a/conf/distro/include/omnect-os-preferred.conf
+++ b/conf/distro/include/omnect-os-preferred.conf
@@ -1,4 +1,5 @@
 PREFERRED_PROVIDER_u-boot-default-script ?= "u-boot-scr"
 PREFERRED_PROVIDER_u-boot-fw-utils ?= "libubootenv"
 PREFERRED_PROVIDER_util-linux-sfdisk-native ?= "util-linux-native"
+PREFERRED_PROVIDER_util-linux-fstrim-native ?= "util-linux-native"
 PREFERRED_PROVIDER_virtual/docker = "docker-moby"

--- a/recipes-core/util-linux/util-linux_%.bbappend
+++ b/recipes-core/util-linux/util-linux_%.bbappend
@@ -1,14 +1,12 @@
 SYSTEMD_AUTO_ENABLE:omnect-os:util-linux-fstrim = "enable"
-#PACKAGECONFIG[systemd] += "--with-systemd --with-systemdsystemunitdir=${systemd_system_unitdir}"
-#PACKAGECONFIG[systemd] = "--with-systemd --with-systemdsystemunitdir=${systemd_system_unitdir}"
-# we don't need cramfs stuff so remove it from deploy dir
+
 do_install:append() {
     # install fstrim's systemd service and timer files
     install -d -m 0755  ${D}${systemd_system_unitdir}
     install -m 0644 ${S}/sys-utils/fstrim.service.in ${D}${systemd_system_unitdir}/fstrim.service
     install -m 0644 ${S}/sys-utils/fstrim.timer ${D}${systemd_system_unitdir}/fstrim.timer
 
-    # remove unused utilities
+    # we don't need cramfs stuff so remove it from deploy dir
     rm -f ${D}${base_sbindir}/fsck.cramfs
     rm -f ${D}${base_sbindir}/mkfs.cramfs
 }

--- a/recipes-core/util-linux/util-linux_%.bbappend
+++ b/recipes-core/util-linux/util-linux_%.bbappend
@@ -1,0 +1,19 @@
+SYSTEMD_AUTO_ENABLE:omnect-os:util-linux-fstrim = "enable"
+#PACKAGECONFIG[systemd] += "--with-systemd --with-systemdsystemunitdir=${systemd_system_unitdir}"
+#PACKAGECONFIG[systemd] = "--with-systemd --with-systemdsystemunitdir=${systemd_system_unitdir}"
+# we don't need cramfs stuff so remove it from deploy dir
+do_install:append() {
+    # install fstrim's systemd service and timer files
+    install -d -m 0755  ${D}${systemd_system_unitdir}
+    install -m 0644 ${S}/sys-utils/fstrim.service.in ${D}${systemd_system_unitdir}/fstrim.service
+    install -m 0644 ${S}/sys-utils/fstrim.timer ${D}${systemd_system_unitdir}/fstrim.timer
+
+    # remove unused utilities
+    rm -f ${D}${base_sbindir}/fsck.cramfs
+    rm -f ${D}${base_sbindir}/mkfs.cramfs
+}
+
+FILES:${PN}:append = "\
+	${systemd_system_unitdir}/fstrim.service \
+	${systemd_system_unitdir}/fstrim.timer \
+"


### PR DESCRIPTION
Filesystem `cramfs` was never used so get rid of related utilities in image.

While utility `fstrim` was already part of the images it wasn't used yet due to missing service and timer files. Added these files to prevent SSD degradation over time because storage devices get never triggered their internal house keeping of used sectors.