### PR TITLE
chore: update to yocto 5.0.17

### DIFF
--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -96,7 +96,7 @@ MACHINE_FEATURES:append = " \
     pstore \
 "
 
-OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy23.bb"
+OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy25.bb"
 
 # force bootloader version checksum to be old, when sure it's 100% binary compatible
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "<newchecksum> <oldchecksum>"
@@ -107,3 +107,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-ph
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
 OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "4ecdcb8049058a82bdf23704b86a9121cd3e543f1d748b262cd3babbf9c7fbe2"
+OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "14a6427252cf1d73b8272ebd539b8aa7a1c878bb36706fffb6371abb7f171ad4 4ecdcb8049058a82bdf23704b86a9121cd3e543f1d748b262cd3babbf9c7fbe2"

--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -96,7 +96,7 @@ MACHINE_FEATURES:append = " \
     pstore \
 "
 
-OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy25.bb"
+OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-phytec-imx_2024.04-2.2.0-phy23.bb"
 
 # force bootloader version checksum to be old, when sure it's 100% binary compatible
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "<newchecksum> <oldchecksum>"
@@ -107,4 +107,3 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_phytec}/recipes-bsp/u-boot/u-boot-ph
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
 OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "4ecdcb8049058a82bdf23704b86a9121cd3e543f1d748b262cd3babbf9c7fbe2"
-OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "14a6427252cf1d73b8272ebd539b8aa7a1c878bb36706fffb6371abb7f171ad4 4ecdcb8049058a82bdf23704b86a9121cd3e543f1d748b262cd3babbf9c7fbe2"

--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -44,4 +44,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/u-boot/u-boot_2024
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
 OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "30dcf10a4ad6bea2e2a483a663f17b4cdca31a62c66c7812766c02eabecc3046"
-OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "637322c28bf62e05889f4ae0c1acc1087d004c896fb2868395a00b00aa653d81 30dcf10a4ad6bea2e2a483a663f17b4cdca31a62c66c7812766c02eabecc3046"
+OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "e121b510c263a56cf42f9c2c08cc8fc9a109c6d4c4bc9255565e0d5eab7454ab 30dcf10a4ad6bea2e2a483a663f17b4cdca31a62c66c7812766c02eabecc3046"

--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -44,3 +44,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/u-boot/u-boot_2024
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
 OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "30dcf10a4ad6bea2e2a483a663f17b4cdca31a62c66c7812766c02eabecc3046"
+OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "637322c28bf62e05889f4ae0c1acc1087d004c896fb2868395a00b00aa653d81 30dcf10a4ad6bea2e2a483a663f17b4cdca31a62c66c7812766c02eabecc3046"

--- a/dynamic-layers/raspberrypi/recipes-bsp/bootloader-versioned/bootloader-versioned.bbappend
+++ b/dynamic-layers/raspberrypi/recipes-bsp/bootloader-versioned/bootloader-versioned.bbappend
@@ -1,3 +1,4 @@
+OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_core}/recipes-bsp/u-boot/u-boot-common.inc"
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_omnect}/dynamic-layers/raspberrypi/recipes-bsp/u-boot/u-boot_%.bbappend"
 OMNECT_BOOTLOADER_CHECKSUM_FILES += "${LAYERDIR_omnect}/dynamic-layers/raspberrypi/recipes-bsp/u-boot/u-boot/*"
 # the u-boot_%.bbappend from meta-raspberrypi is part of BBMASK and thus not part of OMNECT_BOOTLOADER_CHECKSUM_FILES

--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -6,15 +6,15 @@ repos:
   ext/bitbake:
     url: "https://git.openembedded.org/bitbake"
     branch: "2.8"
-    # tag yocto-5.0.16
-    commit: "10118785e4a670bce4980e1044c0888a8b6e84af"
+    # tag yocto-5.0.17
+    commit: "d3b4c352dd33fca90cd31649eda054b884478739"
     layers:
       .: 0
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "scarthgap"
-    # tag yocto-5.0.16
-    commit: "a1f4ae4e569bc0e36c27c1e4651e502e54d63b28"
+    # tag yocto-5.0.17
+    commit: "52380df998b3a8fe6a091f8547434a3231320a8e"
     layers:
       meta:
     patches:
@@ -22,4 +22,4 @@ repos:
         repo: "meta-omnect"
         path: "kas/patches/oe.patch"
 env:
-  OE_VERSION: "5.0.16"
+  OE_VERSION: "5.0.17"

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -10,7 +10,7 @@ repos:
   ext/meta-openembedded:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "4d3e2639dec542b58708244662d5ce36810fc510"
+    commit: "5124ac4a658899158f4a7a2ddf1d2ca931ec7d0e"
     layers:
       # meta-multimedia is used by qemu_8.2.2.imx.bb (tauri) ToDo: possible to handle that in the machine specific kas file?
       meta-multimedia:
@@ -28,13 +28,13 @@ repos:
   ext/meta-security:
     url: "https://git.yoctoproject.org/meta-security"
     branch: "scarthgap"
-    commit: "97e482b71688b62ac1109d16e89368122f039cbf"
+    commit: "b13f1705d723650de61277670c8a76aadea4cfdd"
     layers:
       meta-tpm:
   ext/meta-swupdate:
     url: "https://github.com/sbabic/meta-swupdate.git"
     branch: "scarthgap"
-    commit: "db16b9aa3e39bc35ced39c526606102c9a466b81"
+    commit: "81f4faa406e70dfa514e2f7642f97df33d3b84ae"
   ext/meta-virtualization:
     url: "https://git.yoctoproject.org/meta-virtualization"
     branch: "scarthgap"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,6 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "scarthgap"
+    # for now pinned to our 5.0.15 release, because of https://github.com/phytec/linux-phytec-imx/issues/2
     commit: "951384d6a847a5cfcb9c34e31e2e47c15a91437f"
     patches:
       p001:

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "scarthgap"
-    commit: "951384d6a847a5cfcb9c34e31e2e47c15a91437f"
+    commit: "6145fd1513d701d8b6c5fca9f8db0aaaeeba8a04"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/phytec/phytec.yaml
+++ b/kas/machine/phytec/phytec.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-phytec:
     url: "https://github.com/phytec/meta-phytec"
     branch: "scarthgap"
-    commit: "6145fd1513d701d8b6c5fca9f8db0aaaeeba8a04"
+    commit: "951384d6a847a5cfcb9c34e31e2e47c15a91437f"
     patches:
       p001:
         repo: "meta-omnect"

--- a/kas/machine/x86_64/genericx86-64.yaml
+++ b/kas/machine/x86_64/genericx86-64.yaml
@@ -7,7 +7,7 @@ repos:
   ext/meta-yocto-bsp:
     url: "https://git.yoctoproject.org/meta-yocto"
     branch: scarthgap
-    commit: "9bb6e6e8b016a0c9dfe290369a6ed91ef4020535"
+    commit: "c7c38663a1cafb1fa8593c0b246811e51d3bbe20"
     layers:
       meta-yocto-bsp:
   ext/meta-secure-core:
@@ -25,7 +25,7 @@ repos:
   ext/meta-perl:
     url: "https://github.com/openembedded/meta-openembedded.git"
     branch: "scarthgap"
-    commit: "4d3e2639dec542b58708244662d5ce36810fc510"
+    commit: "5124ac4a658899158f4a7a2ddf1d2ca931ec7d0e"
     layers:
       meta-perl:
 


### PR DESCRIPTION
- updated openembedded-core and bitbake to yocto-5.0.17
- updated meta-openembedded to latest scarthgap head
- updated meta-security to latest scarthgap head
- updated meta-swupdate to latest scarthgap head
- updated meta-yocto repo to latest scarthgap head
- updated meta-secure-core to latest scarthgap head
- raspberry-pi: added openembedded_core/recipes-bsp/u-boot/u-boot-common.inc to `OMNECT_BOOTLOADER_CHECKSUM_FILES`