### PR TITLE
fix(initramfs): prevent stuck system after flash-mode-3 errors

### DIFF
--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -eo pipefail
 grubenv="/boot/EFI/BOOT/grubenv"
 commands=("get" "list" "set" "unset")
 argsc=${#}

--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
@@ -1,4 +1,5 @@
-#!/bin/bash -eo pipefail
+#!/bin/bash -e
+set -o pipefail
 grubenv="/boot/EFI/BOOT/grubenv"
 commands=("get" "list" "set" "unset")
 argsc=${#}

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/flash-mode-3
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/flash-mode-3
@@ -53,8 +53,18 @@ run_bmap_tool() {
 
 # deploy WIC image via network to (same) active block device
 run_flash_mode_3() {
+    # we know that flash mode 3 is active or otherwise flash_mode_3_enabled()
+    # would have failed.
+    # in order to avoid to endlessly fall into this situation if some error
+    # happens below, unset flash-mode variable here right now and also clear
+    # other variables right after having been read
+    set_bootloader_env_var flash-mode
+
     local url=$(get_bootloader_env_var flash-mode-url | base64 --decode) || { msg_fatal "couldn't get \"flash-mode-url\""; return 1; }
+    set_bootloader_env_var flash-mode-url
+
     local url_sha256=$(get_bootloader_env_var flash-mode-url-sha256 | base64 --decode) || { msg_fatal "couldn't get \"flash-mode-url-sha256\""; return 1; }
+    set_bootloader_env_var flash-mode-url-sha256
 
     if [ -z "${url}" ] || [ -z "${url_sha256}" ]; then
         msg "invalid parameters:"
@@ -64,10 +74,6 @@ run_flash_mode_3() {
     fi
 
     msg "Entering omnect flashing mode 3 ..."
-    # disable flash mode for subsequent restarts
-    set_bootloader_env_var flash-mode
-    set_bootloader_env_var flash-mode-url
-    set_bootloader_env_var flash-mode-url-sha256
 
     # we already mounted /dev/omnect/boot when we're using grub. so we unmount before copying boot.
     if [ -f /usr/bin/grub-editenv ]; then


### PR DESCRIPTION
If for whatever reason not all variables required for flash mode 3 got set correctly, the flash-mode-3 init script could fail leaving a system behind with a shell in the initramfs.

Even worse, it was possible that not even a power-cycle could revive the system, because the script left the flash mode operation panding by not cleaning up the environment.

Admittedly, flash modes are generally devlopment-only feature, but possibly having to manually attend a device to sort things out could be rather inconvenient.

This change improves the situation so that at least after having failed a flash mode (3) operation a power cycle brings up the system again as it was before.