### PR TITLE
chore(deps): remove unused sqlite3 dependencies

### DIFF
--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -156,7 +156,10 @@ RDEPENDS:${PN}:pn-gobject-introspection = ""
 SHAREDMIMEDEP:pn-glib-2.0 = ""
 
 # rm not used dependencies from docker:
-DEPENDS:remove:pn-docker-moby = "sqlite btrfs-tools"
+DEPENDS:remove:pn-docker-moby = "sqlite3 btrfs-tools"
+
+# rm not used dependencies from python3:
+DEPENDS:remove:pn-python3 = "sqlite3"
 
 # define default devel tools to be included in image
 OMNECT_DEVEL_TOOLS = "\


### PR DESCRIPTION
Correct the dependency removal for `docker-moby` from `sqlite` to `sqlite3`. 
Additionally, remove `sqlite3` as a dependency for `python3`.