### PR TITLE
fix(bootloader): checksum used was botched

### DIFF
--- a/conf/machine/genericx86-64.extra.conf
+++ b/conf/machine/genericx86-64.extra.conf
@@ -103,5 +103,5 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/grub/grub-efi_2.12
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-bootloader-versioned - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "84ef475f62c9814745aeac6199ab72debff4cff8631339a06098d8749939f499"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "69a43de1bc02f87f36adb29b4215300bda0b4b144ef1505dd71d17f5ae27ff09"
 #OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = ""


### PR DESCRIPTION
... by a temporary local file lying around during build.