### PR TITLE
refactor!: unified extra kernel args and handling for pstore (rpi & tauri)

### DIFF
--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -34,7 +34,7 @@ APPEND += "console=ttymxc2,115200"
 APPEND += "clk-imx8mm.mcore_booted"
 
 # next APPEND options are only needed for reboot reason support
-APPEND:append:omnect_pstore = " ramoops.dump_oops=1 ramoops.ecc=1 printk.always_kmsg_dump=Y crash_kexec_post_notifiers=Y"
+APPEND:append:omnect_pstore = " ramoops.dump_oops=1 printk.always_kmsg_dump=Y crash_kexec_post_notifiers=Y"
 
 # u-boot boot.scr config
 KERNEL_BOOTCMD = "booti"

--- a/conf/machine/include/rpi-pstore.inc
+++ b/conf/machine/include/rpi-pstore.inc
@@ -1,1 +1,1 @@
-CMDLINE:append:pn-rpi-cmdline:omnect_pstore = " ramoops.dump_oops=1 printk.always_kmsg_dump=Y crash_kexec_post_notifiers=Y"
+APPEND:append:omnect_pstore = " ramoops.dump_oops=1 ramoops.ecc=1 printk.always_kmsg_dump=Y crash_kexec_post_notifiers=Y"

--- a/conf/machine/include/rpi-pstore.inc
+++ b/conf/machine/include/rpi-pstore.inc
@@ -1,1 +1,1 @@
-APPEND:append:omnect_pstore = " ramoops.dump_oops=1 ramoops.ecc=1 printk.always_kmsg_dump=Y crash_kexec_post_notifiers=Y"
+APPEND:append:omnect_pstore = " ramoops.dump_oops=1 printk.always_kmsg_dump=Y crash_kexec_post_notifiers=Y"

--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -43,4 +43,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/u-boot/u-boot_2024
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-bootloader-versioned - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "e2b8053780780c1ce641b176daf00edc41ecd6fc0d40cbc64c5adf60751f95c3"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "54427f35455ec78e480e7d2407a9c510cd975159d76c125fd82e66f17f5848bf"

--- a/conf/machine/include/rpi.inc
+++ b/conf/machine/include/rpi.inc
@@ -43,5 +43,4 @@ OMNECT_BOOTLOADER_RECIPE_PATH = "${LAYERDIR_core}/recipes-bsp/u-boot/u-boot_2024
 # OMNECT_BOOTLOADER_CHECKSUM_EXPTECTED:pn-bootloader-versioned - build will fail, if the
 # computed checksum is different to this; set to <oldchecksum> when
 # OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned is set
-OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "30dcf10a4ad6bea2e2a483a663f17b4cdca31a62c66c7812766c02eabecc3046"
-OMNECT_BOOTLOADER_CHECKSUM_COMPATIBLE:pn-bootloader-versioned = "e121b510c263a56cf42f9c2c08cc8fc9a109c6d4c4bc9255565e0d5eab7454ab 30dcf10a4ad6bea2e2a483a663f17b4cdca31a62c66c7812766c02eabecc3046"
+OMNECT_BOOTLOADER_CHECKSUM_EXPECTED:pn-bootloader-versioned = "e2b8053780780c1ce641b176daf00edc41ecd6fc0d40cbc64c5adf60751f95c3"


### PR DESCRIPTION
Previously, the CMDLINE mechanism was used to set suitable kernel arguments for reboot reason (feature pstore) handling what is actually the standard way in the Raspberry Pi BSP.

However, the standard omnect OS way is to use the APPEND mechanism which gets applied to arbitrary bootloaders.

Moreover, for tauri there was an unnecessary ramoops setting (use of ECC) part of the kernel arguments, because it is already part of the device tree add-on that was introduced for reboot reason support.

BREAKING CHANGE: this forces a boot loader update on Raspberry Pi 4.