### PR TITLE
chore(tauri): use the openssl version from oecore

### DIFF
--- a/conf/distro/include/omnect-os-required.conf
+++ b/conf/distro/include/omnect-os-required.conf
@@ -1,0 +1,1 @@
+REQUIRED_VERSION_openssl ?= "3.5.6"

--- a/conf/distro/omnect-os.conf
+++ b/conf/distro/omnect-os.conf
@@ -2,6 +2,7 @@ include conf/machine/${MACHINE}.extra.conf
 require conf/distro/include/omnect-os-distro.conf
 require conf/distro/include/omnect-os-fixes.conf
 require conf/distro/include/omnect-os-preferred.conf
+require conf/distro/include/omnect-os-required.conf
 require conf/distro/include/omnect-os-user_classes.conf
 require conf/distro/include/omnect-os-kernel.conf
 require conf/distro/include/omnect-os-rust.conf

--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -70,6 +70,12 @@ BBMASK:append = " \
     meta-imx/meta-imx-sdk/recipes-graphics/devil/devil_%.bbappend \
 "
 
+# don't let meta-imx-bsp openssl recipe override the one from oecore
+BBMASK:append = " \
+    meta-imx/meta-imx-bsp/recipes-connectivity/openssl/openssl_3.2.6.bb \
+    meta-imx/meta-imx-bsp/recipes-connectivity/openssl/openssl_3.2.%.bbappend \
+"
+
 # fix search path
 FILESEXTRAPATHS:prepend:pn-imx-boot-phytec := "${LAYERDIR_freescale-layer}/recipes-bsp/imx-mkimage/files:"
 FILESEXTRAPATHS:prepend:pn-optee-client := "${LAYERDIR_arm}/recipes-security/optee/optee-client:"


### PR DESCRIPTION
additionally set REQUIRED_VERSION_openssl to hopefully catch if a bsp differs from oecore.