### PR TITLE
fix(bootloader): preserve grubenv across x86-64 bootloader update

### DIFF
--- a/recipes-omnect/images/omnect-os-update-image.bb
+++ b/recipes-omnect/images/omnect-os-update-image.bb
@@ -55,6 +55,7 @@ do_bootloader_package:phytec-imx8mm() {
 do_bootloader_package:omnect_grub() {
     mkdir -p ${WORKDIR}/EFI/BOOT
     for file in ${OMNECT_GRUB_EFI_SB_FILES}; do
+        [ "${file}" = "grubenv" ] && continue
         cp ${DEPLOY_DIR_IMAGE}/${file} ${WORKDIR}/EFI/BOOT/${file}
     done
     cd ${WORKDIR}

--- a/recipes-omnect/initrdscripts/omnect-os-initramfs/resize-data
+++ b/recipes-omnect/initrdscripts/omnect-os-initramfs/resize-data
@@ -4,39 +4,61 @@ resize_data_enabled() {
     return 0
 }
 
+# true if the data partition already fills the disk (no resize needed)
+data_already_resized() {
+    local root_disk="$1"
+    local free_sectors=$(sfdisk -F ${root_disk} 2>/dev/null | sed -n 's/^Unpartitioned space[^,]*, [0-9]* bytes, \([0-9][0-9]*\) sectors$/\1/p')
+    # can't read free space: assume not resized and let the (idempotent) grow
+    # path run rather than risk leaving the partition small
+    [ -z "${free_sectors}" ] && return 1
+    debug "data_already_resized: ${free_sectors} free sectors"
+    # tolerate alignment / GPT-tail slack; genuine unallocated space is GB-scale
+    [ "${free_sectors}" -le 4096 ]
+}
+
 run_resize_data() {
     local resized_data=$(get_bootloader_env_var "resized-data")
-    local ptype=$(get_partition_type)
 
-    # data partition not yet resized
-    if [ -z "${resized_data}" ]; then
-        data_part=$(readlink -f /dev/omnect/data)
-        [[ $(cat /proc/mounts | grep ${data_part} | wc -l) -ne 0 ]] && msg "error: resize_data: \"${data_part}\" is mounted." && return
+    [ -n "${resized_data}" ] && return 0
 
-        root_disk=$(readlink -f /dev/omnect/rootblk)
-        data_part_nr=${data_part:0-1}
-        msg "omnect-os resize data partition: ${root_disk} partition ${data_part_nr}"
+    data_part=$(readlink -f /dev/omnect/data)
+    [[ $(cat /proc/mounts | grep ${data_part} | wc -l) -ne 0 ]] && msg "error: resize_data: \"${data_part}\" is mounted." && return
 
-        if [ "${ptype}" = "gpt" ]; then
-            run_cmd sgdisk ${root_disk} -e
-        elif [ "${ptype}" = "dos" ]; then
-            [[ $(parted ${root_disk} print | grep extended | wc -l) -ne 1 ]] && msg_error "resize_data: couldn't determine extended partion" && return 1
-            extended_part_nr=$(parted ${root_disk} print | grep extended | awk '{print $1}')
-            run_cmd parted ${root_disk} resizepart ${extended_part_nr} 100% || return 1
-        else
-            msg_fatal "unhandled partition type: \"${ptype}\"" && return 1
-        fi
+    root_disk=$(readlink -f /dev/omnect/rootblk)
+    data_part_nr=${data_part:0-1}
 
-        run_cmd parted ${root_disk} resizepart ${data_part_nr} 100% || return 1
-
-        run_cmd ln -sf /proc/self/mounts /etc/mtab || return 1
-        run_cmd e2fsck -y ${data_part} || return 1
-        run_cmd resize2fs -f ${data_part} || return 1
-        run_cmd sync
-
-        # set resized_data in u-boot env
+    # the flag is gone but the partition was already grown on an earlier boot
+    # (e.g. a bootloader update wiped the env): just restore the flag
+    if data_already_resized ${root_disk}; then
+        msg "omnect-os data partition already resized"
         set_bootloader_env_var resized-data 1
+        return 0
     fi
+
+    local ptype=$(get_partition_type)
+    msg "omnect-os resize data partition: ${root_disk} partition ${data_part_nr}"
+
+    if [ "${ptype}" = "gpt" ]; then
+        run_cmd sgdisk ${root_disk} -e
+    elif [ "${ptype}" = "dos" ]; then
+        [[ $(parted -s ${root_disk} print | grep extended | wc -l) -ne 1 ]] && msg_error "resize_data: couldn't determine extended partion" && return 1
+        extended_part_nr=$(parted -s ${root_disk} print | grep extended | awk '{print $1}')
+        run_cmd parted -s ${root_disk} resizepart ${extended_part_nr} 100% || return 1
+    else
+        msg_fatal "unhandled partition type: \"${ptype}\"" && return 1
+    fi
+
+    run_cmd parted -s ${root_disk} resizepart ${data_part_nr} 100% || return 1
+
+    run_cmd ln -sf /proc/self/mounts /etc/mtab || return 1
+    # e2fsck exit 1 means it corrected errors, which is not a failure here
+    run_cmd e2fsck -y ${data_part}
+    [ $? -gt 1 ] && return 1
+    run_cmd resize2fs -f ${data_part} || return 1
+    run_cmd sync
+
+    set_bootloader_env_var resized-data 1
+
     return 0
 }
 


### PR DESCRIPTION
On genericx86-64 the bootloader update payload was built from OMNECT_GRUB_EFI_SB_FILES, which includes grubenv. Applying it via 'swupdate -e stable,bootloader' extracted the archive onto /boot and overwrote the device's live /boot/EFI/BOOT/grubenv with the blank build-time template, wiping all persisted boot state (omnect_os_bootpart, the omnect_validate_update* machine, omnect_extra_bootargs, omnect_rootblk and resized-data).

Losing resized-data re-triggered the initramfs resize-data stage on an already-resized disk, which failed and fatal-looped release images with 'FATAL ERROR: iniramfs failed: resize_data'.

Exclude grubenv from do_bootloader_package:omnect_grub so the update no longer carries it; swupdate's archive handler only extracts listed files, so the on-disk grubenv is preserved. OMNECT_GRUB_EFI_SB_FILES is unchanged, so the WIC plugin still installs grubenv into the initial boot partition.

Also make resize-data idempotent as defense-in-depth: detect an already-resized data partition via sfdisk -F and just restore the flag, run parted in script mode so it cannot block on a prompt, and accept e2fsck exit 1 (errors corrected) instead of aborting the boot.