### PR TITLE
chore(security): silence meta-security DISTRO_FEATURES warning

### DIFF
--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -8,6 +8,12 @@ SDK_VERSION = "${MACHINE}-${DISTRO_VERSION}"
 DISTRO_FEATURES = "apparmor ipv4 ipv6 polkit seccomp xattr zeroconf"
 DISTRO_FEATURES_BACKFILL_CONSIDERED += "pulseaudio gobject-introspection-data ldconfig"
 
+# meta-security is only included for the AppArmor userspace; the 'security'
+# DISTRO_FEATURE would pull in kernel config fragments for linux-yocto, but we
+# manage the kernel config ourselves for all kernels. Skip the layer's sanity
+# warning instead of enabling the feature.
+SKIP_META_SECURITY_SANITY_CHECK = "1"
+
 # DISTRO_FEATURES depending on MACHINE_FEATURES:
 # only 3g remains here; wifi/bluetooth now come from device_caps.json (below).
 DISTRO_FEATURES += "${@bb.utils.contains('MACHINE_FEATURES', '3g', '3g', '', d)}"


### PR DESCRIPTION
## Why

Every build prints:

    WARNING: You have included the meta-security layer, but 'security' has not
    been enabled in your DISTRO_FEATURES. ...

We include meta-security only for the AppArmor userspace. In meta-security
(scarthgap) the 'security' DISTRO_FEATURE gates exactly one relevant thing:
the linux-yocto bbappends that add kernel config fragments from the
kernel-cache (e.g. `features/apparmor/apparmor.scc`).

Enabling the feature would be wrong for us:
- it only affects linux-yocto machines, so kernel configs would diverge from
  linux-raspberrypi / linux-phytec-imx, which we keep uniform via our own
  fragments
- the kernel-cache apparmor feature can conflict with our deliberate config
  (AppArmor compiled in but inactive, DAC default, see `audit.cfg` and
  `doc/mac_lsm.md`)