### PR TITLE
chore(adu): update iot-hub-device-update to 1.4.0

### DIFF
--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
@@ -1,8 +1,8 @@
 diff --git a/CMakeLists.txt b/CMakeLists.txt
-index eb156b36..7ae2cb2e 100644
+index 0574fed5..a489288e 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -231,7 +231,7 @@ set (
+@@ -236,7 +236,7 @@ set (
      ADUC_STEP_HANDLER_NAME_TO_DIRECOTRY_MAP
      "microsoft/apt,apt_handler" "microsoft/script,script_handler"
      "microsoft/simulator,simulator_handler" "microsoft/swupdate_v2,swupdate_handler_v2"
@@ -11,7 +11,7 @@ index eb156b36..7ae2cb2e 100644
  
  if (WIN32)
      set (
-@@ -416,6 +416,11 @@ set (
+@@ -426,6 +426,11 @@ set (
      "syslog"
      CACHE STRING "The syslog group.")
  
@@ -24,41 +24,52 @@ index eb156b36..7ae2cb2e 100644
      ADUC_IOT_HUB_PROTOCOL
      "IotHub_Protocol_from_Config"
 diff --git a/scripts/error_code_generator_defs/result_codes.json b/scripts/error_code_generator_defs/result_codes.json
-index 6fc707cf..11d4e4b4 100644
+index 686fce7d..32357462 100644
 --- a/scripts/error_code_generator_defs/result_codes.json
 +++ b/scripts/error_code_generator_defs/result_codes.json
-@@ -369,6 +369,10 @@
-                             "name": "ADUC_ERC_SWUPDATE_HANDLER_APPLY_FAILED_TO_GET_CONFIG_INSTANCE",
-                             "value": 769
-                         },
-+                        {
-+                            "name": "ADUC_ERC_SWUPDATE_HANDLER_INSTALL_FAILURE_VALIDATION",
-+                            "value": 800
-+                        },
-                         {
-                             "name": "ADUC_ERC_SWUPDATE_HANDLER_CANCEL_FAILURE",
-                             "value": 1024
-@@ -1461,4 +1465,4 @@
+@@ -1371,4 +1371,4 @@
              "name": "ADUC_FACILITY_UNUSED_F"
          }
      ]
 -}
 +}
 \ No newline at end of file
-diff --git a/src/adu-shell/inc/adushell.hpp b/src/adu-shell/inc/adushell.hpp
-index 7f474373..c824a04f 100644
---- a/src/adu-shell/inc/adushell.hpp
-+++ b/src/adu-shell/inc/adushell.hpp
-@@ -38,7 +38,6 @@ typedef struct tagADUShell_LaunchArguments
-  */
- #define ADUSHELL_EXIT_UNSUPPORTED 3
- #define ADUSHELL_EXIT_BAD_FILE_PERMS 4
--#define ADUSHELL_EXIT_BAD_FILE_OWNERSHIP 5
+diff --git a/scripts/install-deps.sh b/scripts/install-deps.sh
+index 1871bae9..50bf1987 100755
+--- a/scripts/install-deps.sh
++++ b/scripts/install-deps.sh
+@@ -130,7 +130,7 @@ mark_dep_installed() {
+ }
  
- /**
-  * @brief An exit code for early exit of adu-shell process due to SIGTERM/SIGINT signal handling.
+ # Dependencies packages
+-aduc_packages=('git' 'make' 'build-essential' 'cmake' 'ninja-build' 'libcurl4-openssl-dev' 'libssl-dev' 'uuid-dev' 'lsb-release' 'curl' 'wget' 'pkg-config' 'libxml2-dev' 'file')
++aduc_packages=('git' 'make' 'build-essential' 'cmake' 'ninja-build' 'libcurl4-openssl-dev' 'libssl-dev' 'uuid-dev' 'lsb-release' 'curl' 'wget' 'pkg-config' 'libxml2-dev' 'file' 'libsystemd-dev')
+ static_analysis_packages=('clang' 'clang-tidy' 'cppcheck')
+ compiler_packages=('gcc' 'g++')
+ 
+diff --git a/src/adu-shell/scripts/adu-reboot-wrapper.sh b/src/adu-shell/scripts/adu-reboot-wrapper.sh
+index fbc6546b..d690ea1b 100644
+--- a/src/adu-shell/scripts/adu-reboot-wrapper.sh
++++ b/src/adu-shell/scripts/adu-reboot-wrapper.sh
+@@ -35,10 +35,12 @@ done
+ rm -f "$LOCK_FILE" 2> /dev/null
+ 
+ if [ $elapsed -ge "$TIMEOUT" ]; then
+-    echo "ADU Reboot Wrapper: Timeout reached after ${elapsed}s, forcing reboot"
++    echo "ADU Reboot Wrapper: Timeout reached after ${elapsed}s; adu-shell will reboot"
+ else
+-    echo "ADU Reboot Wrapper: Agent ready after ${elapsed}s, proceeding with reboot"
++    echo "ADU Reboot Wrapper: Agent ready after ${elapsed}s; adu-shell will reboot"
+ fi
+ 
+-# Perform actual reboot
+-exec /sbin/reboot "$@"
++# This wrapper only waits for the agent. adu-shell performs the actual reboot
++# via the reboot(2) syscall (CAP_SYS_BOOT) after this script returns, so no
++# privileged reboot child process is spawned here.
++exit 0
 diff --git a/src/adu-shell/src/common_tasks.cpp b/src/adu-shell/src/common_tasks.cpp
-index b427a930..0f68e920 100644
+index 770f8bd4..11fc68ad 100644
 --- a/src/adu-shell/src/common_tasks.cpp
 +++ b/src/adu-shell/src/common_tasks.cpp
 @@ -5,6 +5,10 @@
@@ -72,21 +83,50 @@ index b427a930..0f68e920 100644
  #include "common_tasks.hpp"
  #include "aduc/process_utils.hpp"
  
-@@ -25,11 +29,36 @@ namespace Common
+@@ -25,26 +29,55 @@ namespace Common
   */
  ADUShellTaskResult Reboot(const ADUShell_LaunchArguments& /*launchArgs*/)
  {
--    Log_Info("Launching child process to reboot the device.");
-+    Log_Info("Calling reboot(RB_AUTOBOOT) directly using CAP_SYS_BOOT capability.");
-+    ADUShellTaskResult taskResult;
+-    Log_Info("Calling reboot wrapper to synchronize with agent cleanup.");
+     ADUShellTaskResult taskResult;
+-    // Use adu-reboot-wrapper.sh which waits for lock file removal
+-    // The agent creates /var/run/adu-agent-reboot.lock before calling this
+-    // and removes it after caching and reporting status to cloud
 +
-+    if (::reboot(RB_AUTOBOOT) != 0)
++    // Wait for the agent to finish caching updates and reporting status to the
++    // cloud before we reboot. The agent holds /var/run/adu-agent-reboot.lock
++    // while it prepares; the wrapper polls until the lock is gone (or a timeout)
++    // and then returns. This preserves the sandbox so downloads can resume after
++    // restart. The wrapper only waits — it does not reboot. The reboot itself is
++    // the in-process reboot(2) syscall below, using adu-shell's CAP_SYS_BOOT
++    // capability, so no privileged child process is spawned for it.
+     std::vector<std::string> args{};
+     std::string output;
+-    int exitCode = ADUC_LaunchChildProcess("/usr/lib/adu/adu-reboot-wrapper.sh", args, output);
+-
+-    if (exitCode == 0)
++    int waitExitCode = ADUC_LaunchChildProcess("/usr/lib/adu/adu-reboot-wrapper.sh", args, output);
++    if (!output.empty())
 +    {
++        Log_Info(output.c_str());
++    }
++    if (waitExitCode != 0)
+     {
+-        Log_Info("Reboot wrapper completed successfully.");
++        Log_Warn("Reboot wrapper returned %d; proceeding with reboot anyway.", waitExitCode);
+     }
+-    else
++
++    Log_Info("Calling reboot(RB_AUTOBOOT) directly using CAP_SYS_BOOT capability.");
++    if (::reboot(RB_AUTOBOOT) != 0)
+     {
+-        Log_Error("Reboot wrapper failed, exit code: %d", exitCode);
 +        const int saved_errno = errno;
 +        Log_Error("reboot(RB_AUTOBOOT) failed (errno: %d)", saved_errno);
 +        taskResult.SetExitStatus(saved_errno);
-+    }
-+
+     }
+ 
+-    taskResult.SetExitStatus(exitCode);
 +    return taskResult;
 +}
 +
@@ -94,13 +134,11 @@ index b427a930..0f68e920 100644
 +
 +ADUShellTaskResult DoRebootReason(const char* reason)
 +{
-     ADUShellTaskResult taskResult;
--    std::vector<std::string> args{ "--reboot", "--no-wall" };
++    ADUShellTaskResult taskResult;
 +    std::vector<std::string> args{ "log", reason };
-     std::string output;
--    taskResult.SetExitStatus(ADUC_LaunchChildProcess("/sbin/reboot", args, output));
++    std::string output;
 +    const char* script;
-+
+ 
 +    Log_Info("Launching child process to record reboot reason (\"%s\")", reason);
 +
 +    script = getenv("OMNECT_LOG_REBOOT_REASON_SCRIPT");
@@ -112,7 +150,7 @@ index b427a930..0f68e920 100644
      if (!output.empty())
      {
          Log_Info(output.c_str());
-@@ -66,6 +95,16 @@ ADUShellTaskResult DoCommonTask(const ADUShell_LaunchArguments& launchArgs)
+@@ -81,6 +114,16 @@ ADUShellTaskResult DoCommonTask(const ADUShell_LaunchArguments& launchArgs)
          taskResult.SetExitStatus(ADUSHELL_EXIT_UNSUPPORTED);
      }
  
@@ -183,18 +221,39 @@ index cf1f3bd5..0d715d2b 100644
      ADUC_ConfigInfo_ReleaseInstance(config);
      return ret;
 diff --git a/src/adu-shell/src/script_tasks.cpp b/src/adu-shell/src/script_tasks.cpp
-index 679d941d..1c570640 100644
+index adbd4446..50570a60 100644
 --- a/src/adu-shell/src/script_tasks.cpp
 +++ b/src/adu-shell/src/script_tasks.cpp
-@@ -51,21 +51,6 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
+@@ -49,11 +49,8 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
+     const char* path = launchArgs.targetData;
+     struct stat st = {};
+     bool filePermissionsChanged = false;
+-    bool fileOwnershipChanged = false;
      int mode = S_IRWXU | S_IRGRP | S_IXGRP;
-     if (statOk)
-     {
--        // Ensure that the script has the correct ownership.
--        struct group* grp = ADUCPAL_getgrnam(ADUC_FILE_GROUP);
--        struct passwd* p = ADUCPAL_getpwnam(ADUC_FILE_USER);
+     int originalMode = 0;
+-    uid_t originalUid = 0;
+-    gid_t originalGid = 0;
+ 
+     // Do not attempt to execute a script that does not exist. Otherwise the
+     // child process launch below would fail with a hard-to-diagnose error.
+@@ -64,31 +61,9 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
+         return taskResult;
+     }
+ 
+-    // Remember the original permissions and ownership so they can be restored after execution.
++    // Remember the original permissions so they can be restored after execution.
++    // omnect intentionally does not change or restore the script ownership (no chown).
+     originalMode = st.st_mode & ~S_IFMT;
+-    originalUid = st.st_uid;
+-    originalGid = st.st_gid;
 -
--        if (p != NULL && grp != NULL)
+-    // Ensure that the script has the correct ownership.
+-    struct group* grp = ADUCPAL_getgrnam(ADUC_FILE_GROUP);
+-    struct passwd* p = ADUCPAL_getpwnam(ADUC_FILE_USER);
+-
+-    if (p != NULL && grp != NULL)
+-    {
+-        if (originalUid != p->pw_uid || originalGid != grp->gr_gid)
 -        {
 -            // Fix the ownership.
 -            if (0 != ADUCPAL_chown(path, p->pw_uid, grp->gr_gid))
@@ -203,66 +262,86 @@ index 679d941d..1c570640 100644
 -                taskResult.SetExitStatus(ADUSHELL_EXIT_BAD_FILE_OWNERSHIP);
 -                goto done;
 -            }
--        }
 -
-         int perms = st.st_mode & ~S_IFMT;
-         if (perms != mode)
-         {
+-            // The ownership was successfully changed and must be restored after execution.
+-            fileOwnershipChanged = true;
+-        }
+-    }
+ 
+     if (originalMode != mode)
+     {
+@@ -109,17 +84,6 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
+     taskResult.SetExitStatus(ADUC_LaunchChildProcess(launchArgs.targetData, args, taskResult.Output()));
+ 
+ done:
+-    // Restore the original ownership if it was changed. This is done before
+-    // restoring the permissions because chown() may clear the set-user-ID and
+-    // set-group-ID permission bits.
+-    if (fileOwnershipChanged)
+-    {
+-        if (0 != ADUCPAL_chown(path, originalUid, originalGid))
+-        {
+-            Log_Warn("Failed to restore '%s' file ownership", path);
+-        }
+-    }
+-
+     // Restore the original permissions if they were changed.
+     if (filePermissionsChanged)
+     {
 diff --git a/src/adu-shell/tests/adushell_ut.cpp b/src/adu-shell/tests/adushell_ut.cpp
-index bb0ee839..dc118d02 100644
+index 292f84da..f9e1596a 100644
 --- a/src/adu-shell/tests/adushell_ut.cpp
 +++ b/src/adu-shell/tests/adushell_ut.cpp
-@@ -13,6 +13,7 @@
- 
+@@ -14,6 +14,7 @@
  #include <catch2/catch_all.hpp>
  
+ #include <atomic>
 +#include <cerrno>
+ #include <chrono>
  #include <filesystem>
  #include <fstream>
- #include <string>
-@@ -178,7 +179,7 @@ TEST_CASE("AptGet rollback appends output from cleanup phase")
+@@ -229,7 +230,7 @@ TEST_CASE("AptGet rollback appends output from cleanup phase")
      CHECK(taskResult.Output() == "phasephase");
  }
  
 -TEST_CASE("Common reboot task dispatches reboot command")
-+TEST_CASE("Common reboot task calls reboot syscall directly, not a child process")
++TEST_CASE("Common reboot task waits via the reboot wrapper, then calls reboot syscall directly")
  {
      g_launchCapture.Reset();
  
-@@ -186,11 +187,12 @@ TEST_CASE("Common reboot task dispatches reboot command")
+@@ -237,9 +238,15 @@ TEST_CASE("Common reboot task dispatches reboot command")
  
      auto taskResult = Adu::Shell::Tasks::Common::Reboot(launchArgs);
  
 -    CHECK(taskResult.ExitStatus() == 0);
--    CHECK(g_launchCapture.command == "/sbin/reboot");
--    REQUIRE(g_launchCapture.args.size() == 2);
--    CHECK(g_launchCapture.args[0] == "--reboot");
--    CHECK(g_launchCapture.args[1] == "--no-wall");
-+    // No child process must be launched — reboot() is called in-process.
-+    CHECK(g_launchCapture.command.empty());
++    // The only child process launched is the wrapper, which waits for the
++    // agent to finish caching and reporting before the reboot proceeds.
+     CHECK(g_launchCapture.command == "/usr/lib/adu/adu-reboot-wrapper.sh");
+     REQUIRE(g_launchCapture.args.size() == 0);
 +
-+    // In the test environment (no CAP_SYS_BOOT), reboot(2) returns EPERM.
-+    // A non-zero exit confirms the syscall was attempted and failed gracefully.
++    // The reboot itself is the in-process reboot(2) syscall. In the test
++    // environment (no CAP_SYS_BOOT), reboot(2) returns EPERM. A non-zero exit
++    // confirms the syscall was attempted and failed gracefully.
 +    CHECK(taskResult.ExitStatus() == EPERM);
  }
  
  TEST_CASE("Common task handles unsupported action path")
 diff --git a/src/adu_workflow/src/agent_workflow.c b/src/adu_workflow/src/agent_workflow.c
-index 9a0bc38e..f8074c01 100644
+index 524747b7..38c7e70f 100644
 --- a/src/adu_workflow/src/agent_workflow.c
 +++ b/src/adu_workflow/src/agent_workflow.c
-@@ -35,6 +35,10 @@
- 
+@@ -38,6 +38,10 @@
  #include <pthread.h>
+ #include <stdbool.h>
  
 +#include <sys/inotify.h>
 +#define INOTIFY_EVENT_SIZE      ( sizeof (struct inotify_event) )
 +#define INOTIFY_EVENT_BUF_LEN   ( 1024 * ( INOTIFY_EVENT_SIZE + 16 ) )
 +
  // fwd decl
- void ADUC_Workflow_WorkCompletionCallback(const void* workCompletionToken, ADUC_Result result, bool isAsync);
- 
-@@ -356,6 +360,45 @@ void ADUC_Workflow_DoWork(ADUC_WorkflowData* workflowData)
+ static void s_onPauseTimerStart();
+ static void s_onPauseTimerStop();
+@@ -412,6 +416,45 @@ void ADUC_Workflow_DoWork(ADUC_WorkflowData* workflowData)
  
  void ADUC_Workflow_HandleStartupWorkflowData(ADUC_WorkflowData* currentWorkflowData)
  {
@@ -308,7 +387,7 @@ index 9a0bc38e..f8074c01 100644
      if (currentWorkflowData == NULL)
      {
          Log_Info("No update content. Ignoring.");
-@@ -557,11 +600,17 @@ void ADUC_Workflow_HandlePropertyUpdate(
+@@ -614,11 +657,17 @@ void ADUC_Workflow_HandlePropertyUpdate(
  
                      Log_Debug("deferral not needed. Processing '%s' now", workflow_peek_id(nextWorkflow));
  
@@ -330,14 +409,6 @@ index 9a0bc38e..f8074c01 100644
                  }
  
                  // Fall through to handle new workflow
-@@ -991,7 +1040,6 @@ void ADUC_Workflow_WorkCompletionCallback(const void* workCompletionToken, ADUC_
-                     // Reset workflow state to process deployment and transfer
-                     // the deferred workflow to current.
-                     workflow_update_for_replacement(workflowData->WorkflowHandle);
--
-                 }
-                 else
-                 {
 diff --git a/src/agent/src/health_management.c b/src/agent/src/health_management.c
 index 38ad9ea5..b32dcc33 100644
 --- a/src/agent/src/health_management.c
@@ -355,20 +426,20 @@ index 38ad9ea5..b32dcc33 100644
              S_IRGRP | S_IXGRP;  // R-X group
          // clang-format on
 diff --git a/src/agent/src/main.c b/src/agent/src/main.c
-index 7b37d369..8612524d 100644
+index 70f28c4f..6a350e07 100644
 --- a/src/agent/src/main.c
 +++ b/src/agent/src/main.c
-@@ -831,7 +831,7 @@ done:
+@@ -886,7 +886,7 @@ done:
   */
  void ShutdownAgent()
  {
 -    Log_Warn("Agent is shutting down.");
 +    Log_Info("Agent is shutting down.");
-     ADUC_D2C_Messaging_Uninit();
- #ifdef ADUC_COMMAND_HELPER_H
-     Log_Debug("Shutdown step: UninitializeCommandListenerThread");
+ 
+     AducTimer_Stop(&g_idle_pause_timer);
+ 
 diff --git a/src/communication_managers/iothub_communication_manager/CMakeLists.txt b/src/communication_managers/iothub_communication_manager/CMakeLists.txt
-index 048a4b0c..80ae283f 100644
+index 0e52b667..8620349c 100644
 --- a/src/communication_managers/iothub_communication_manager/CMakeLists.txt
 +++ b/src/communication_managers/iothub_communication_manager/CMakeLists.txt
 @@ -29,7 +29,8 @@ target_link_libraries (
@@ -382,7 +453,7 @@ index 048a4b0c..80ae283f 100644
  target_link_libraries (${target_name} PRIVATE libaducpal)
  
 diff --git a/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c b/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
-index b0c3dfcc..e86442c1 100644
+index 89a2523c..563feb37 100644
 --- a/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
 +++ b/src/communication_managers/iothub_communication_manager/src/iothub_communication_manager.c
 @@ -43,6 +43,8 @@
@@ -406,7 +477,7 @@ index b0c3dfcc..e86442c1 100644
  /**
   * @brief An additional data context used the caller.
   */
-@@ -234,6 +241,11 @@ void IoTHub_CommunicationManager_ConnectionStatus_Callback(
+@@ -337,6 +344,11 @@ void IoTHub_CommunicationManager_ConnectionStatus_Callback(
      case IOTHUB_CLIENT_CONNECTION_AUTHENTICATED:
          g_last_authenticated_time = now_time;
          g_authentication_retries = 0;
@@ -417,7 +488,37 @@ index b0c3dfcc..e86442c1 100644
 +        }
          break;
      case IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED:
-         if (g_last_authenticated_time >= g_first_unauthenticated_time)
+         if (IoTHub_CommunicationManager_CategorizeUnauthenticated(status_reason)
+diff --git a/src/communication_managers/iothub_communication_manager/tests/CMakeLists.txt b/src/communication_managers/iothub_communication_manager/tests/CMakeLists.txt
+index dbd6d5b5..69868fc4 100644
+--- a/src/communication_managers/iothub_communication_manager/tests/CMakeLists.txt
++++ b/src/communication_managers/iothub_communication_manager/tests/CMakeLists.txt
+@@ -26,8 +26,9 @@ target_link_aziotsharedutil (${PROJECT_NAME} PRIVATE)
+ 
+ target_link_libraries (
+     ${PROJECT_NAME}
+-    PUBLIC IotHubClient::iothub_client iothub_client_mqtt_transport iothub_client_mqtt_ws_transport umqtt
+-    PRIVATE aduc::iothub_communication_manager
++    PRIVATE IotHubClient::iothub_client
++            umqtt
++            aduc::iothub_communication_manager
+             aduc::communication_abstraction
+             aduc::adu_types
+             aduc::c_utils
+@@ -36,6 +37,13 @@ target_link_libraries (
+             Catch2::Catch2WithMain
+             libaducpal)
+ 
++# Link the MQTT transports last, like the agent target does. They are static
++# archives that pull umqtt/aziotsharedutil symbols, so their link order is
++# sensitive; omnect's systemd dependency on iothub_communication_manager shifts
++# the order enough to break resolution when they are listed earlier.
++target_link_libraries (${PROJECT_NAME}
++                       PRIVATE iothub_client_mqtt_transport iothub_client_mqtt_ws_transport)
++
+ target_compile_definitions (${PROJECT_NAME} PRIVATE ADUC_CONF_FILE_PATH="/etc/adu/du-config.json")
+ 
+ include (CTest)
 diff --git a/src/diagnostics_component/diagnostics_workflow/CMakeLists.txt b/src/diagnostics_component/diagnostics_workflow/CMakeLists.txt
 index dc064d3b..15c516fc 100644
 --- a/src/diagnostics_component/diagnostics_workflow/CMakeLists.txt
@@ -457,6 +558,34 @@ index 6ce04d11..d238d300 100644
  
  #include <diagnostics_config_utils.h>
  #include <diagnostics_devicename.h>
+diff --git a/src/diagnostics_component/diagnostics_workflow/tests/diagnostics_workflow_ut.cpp b/src/diagnostics_component/diagnostics_workflow/tests/diagnostics_workflow_ut.cpp
+index b0e6823e..b3e0e5a4 100644
+--- a/src/diagnostics_component/diagnostics_workflow/tests/diagnostics_workflow_ut.cpp
++++ b/src/diagnostics_component/diagnostics_workflow/tests/diagnostics_workflow_ut.cpp
+@@ -429,6 +429,11 @@ TEST_CASE("DiagnosticsWorkflow_GetFilesForComponent")
+ // ============================================================================
+ TEST_CASE("DiagnosticsWorkflow_UploadFilesForComponent")
+ {
++    // omnect builds without diagnostic_utils::file_upload_utility, so the blob
++    // upload is stubbed out and always fails. This test exercises the real
++    // upload path, so skip it.
++    SKIP("diagnostics blob upload (file_upload_utility) is disabled in omnect");
++
+     DiagnosticsWorkflowTestHelper helper;
+ 
+     SECTION("NULL fileNames returns Failure")
+@@ -666,6 +671,11 @@ TEST_CASE("DiagnosticsWorkflow_UnInitLogComponentFileNames")
+ // ============================================================================
+ TEST_CASE("DiagnosticsWorkflow_DiscoverAndUploadLogs")
+ {
++    // omnect builds without diagnostic_utils::file_upload_utility, so the blob
++    // upload is stubbed out and always fails. This test exercises the real
++    // upload path, so skip it.
++    SKIP("diagnostics blob upload (file_upload_utility) is disabled in omnect");
++
+     DiagnosticsWorkflowTestHelper helper;
+ 
+     SECTION("NULL jsonString reports failure")
 diff --git a/src/diagnostics_component/utils/CMakeLists.txt b/src/diagnostics_component/utils/CMakeLists.txt
 index 2952f344..811a22f1 100644
 --- a/src/diagnostics_component/utils/CMakeLists.txt
@@ -1267,6 +1396,20 @@ index 00000000..891e09b8
 +    ADUC_Result result = { ADUC_Result_Restore_Success };
 +    return result;
 +}
+diff --git a/src/extensions/step_handlers/swupdate_handler_v2/inc/aduc/swupdate_handler_result_codes.h b/src/extensions/step_handlers/swupdate_handler_v2/inc/aduc/swupdate_handler_result_codes.h
+index 11e68b88..385e2afc 100644
+--- a/src/extensions/step_handlers/swupdate_handler_v2/inc/aduc/swupdate_handler_result_codes.h
++++ b/src/extensions/step_handlers/swupdate_handler_v2/inc/aduc/swupdate_handler_result_codes.h
+@@ -135,6 +135,9 @@
+ /** Max retries exceeded during apply reboot | ADUC_ERC_SWUPDATE_HANDLER_APPLY_REBOOT_FAILURE_MAX_RETRIES_EXCEEDED = 806355714 (0x30100302) */
+ #define ADUC_ERC_SWUPDATE_HANDLER_APPLY_REBOOT_FAILURE_MAX_RETRIES_EXCEEDED 0x30100302
+ 
++/** Update validation on the new boot partition failed; rebooted to the old boot partition | ADUC_ERC_SWUPDATE_HANDLER_INSTALL_FAILURE_VALIDATION = 806355744 (0x30100320) */
++#define ADUC_ERC_SWUPDATE_HANDLER_INSTALL_FAILURE_VALIDATION 0x30100320
++
+ /** Cancel operation failed | ADUC_ERC_SWUPDATE_HANDLER_CANCEL_FAILURE = 806355968 (0x30100400) */
+ #define ADUC_ERC_SWUPDATE_HANDLER_CANCEL_FAILURE 0x30100400
+ 
 diff --git a/src/extensions/step_handlers/swupdate_handler_v2/inc/aduc/swupdate_handler_v2.hpp b/src/extensions/step_handlers/swupdate_handler_v2/inc/aduc/swupdate_handler_v2.hpp
 index 3c8b2157..26843f49 100644
 --- a/src/extensions/step_handlers/swupdate_handler_v2/inc/aduc/swupdate_handler_v2.hpp
@@ -1284,12 +1427,12 @@ index 3c8b2157..26843f49 100644
  protected:
      //!< Protected constructor, must call CreateContentHandler factory method or from derived simulator class
 diff --git a/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp b/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
-index 6fa3acd6..883f1769 100644
+index 670f54aa..7b24359b 100644
 --- a/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
 +++ b/src/extensions/step_handlers/swupdate_handler_v2/src/swupdate_handler_v2.cpp
-@@ -38,6 +38,9 @@
- #define HANDLER_PROPERTIES_API_VERSION "apiVersion"
+@@ -39,6 +39,9 @@
  #define HANDLER_ARG_ACTION "--action"
+ #define HANDLER_ARG_WORKFLOW_ID "--workflow-id"
  
 +#define ADUC_SWUPDATE_CONSENT_CONF_FILE "/etc/omnect/consent/consent_conf.json"
 +#define ADUC_SWUPDATE_CONSENT_USER_FILE "/etc/omnect/consent/swupdate/user_consent.json"
@@ -1297,7 +1440,7 @@ index 6fa3acd6..883f1769 100644
  namespace adushconst = Adu::Shell::Const;
  
  struct JSONValueDeleter
-@@ -58,6 +61,59 @@ SWUpdateHandlerImpl::~SWUpdateHandlerImpl() // override
+@@ -59,6 +62,59 @@ SWUpdateHandlerImpl::~SWUpdateHandlerImpl() // override
      ADUC_Logging_Uninit();
  }
  
@@ -1357,7 +1500,7 @@ index 6fa3acd6..883f1769 100644
  /**
   * @brief Downloads a main script file into a sandbox folder.
   *        The 'handlerProperties["scriptFileName"]' contains the main script file name.
-@@ -332,12 +388,53 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
+@@ -412,12 +468,53 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
      memset(&fileEntity, 0, sizeof(fileEntity));
      size_t fileCount = workflow_get_update_files_count(workflowHandle);
      ADUC_Result result = SWUpdate_Handler_DownloadScriptFile(workflowHandle);
@@ -1411,7 +1554,7 @@ index 6fa3acd6..883f1769 100644
      // Determine whether to continue downloading the rest.
      installedCriteria = workflow_get_installed_criteria(workflowData->WorkflowHandle);
      result = IsInstalled(workflowData);
-@@ -348,6 +445,16 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
+@@ -428,6 +525,16 @@ ADUC_Result SWUpdateHandlerImpl::Download(const tagADUC_WorkflowData* workflowDa
          goto done;
      }
  
@@ -1428,17 +1571,36 @@ index 6fa3acd6..883f1769 100644
      result = { ADUC_Result_Download_Success };
  
      for (size_t i = 0; i < fileCount; i++)
-diff --git a/src/inc/aduc/result.h b/src/inc/aduc/result.h
-index d9e00095..9d7bbe7c 100644
---- a/src/inc/aduc/result.h
-+++ b/src/inc/aduc/result.h
-@@ -2037,4 +2037,4 @@ static inline ADUC_Result_t MAKE_ADUC_DELIVERY_OPTIMIZATION_EXTENDEDRESULTCODE(c
+diff --git a/src/extensions/step_handlers/swupdate_handler_v2/swupdate_handler_result_codes.json b/src/extensions/step_handlers/swupdate_handler_v2/swupdate_handler_result_codes.json
+index 7d61c89f..0acbf784 100644
+--- a/src/extensions/step_handlers/swupdate_handler_v2/swupdate_handler_result_codes.json
++++ b/src/extensions/step_handlers/swupdate_handler_v2/swupdate_handler_result_codes.json
+@@ -175,6 +175,11 @@
+             "value": 770,
+             "description": "Max retries exceeded during apply reboot"
+         },
++        {
++            "name": "ADUC_ERC_SWUPDATE_HANDLER_INSTALL_FAILURE_VALIDATION",
++            "value": 800,
++            "description": "Update validation on the new boot partition failed; rebooted to the old boot partition"
++        },
+         {
+             "name": "ADUC_ERC_SWUPDATE_HANDLER_CANCEL_FAILURE",
+             "value": 1024,
+diff --git a/src/inc/aduc/swupdate_handler_result_codes.h b/src/inc/aduc/swupdate_handler_result_codes.h
+index 11e68b88..385e2afc 100644
+--- a/src/inc/aduc/swupdate_handler_result_codes.h
++++ b/src/inc/aduc/swupdate_handler_result_codes.h
+@@ -135,6 +135,9 @@
+ /** Max retries exceeded during apply reboot | ADUC_ERC_SWUPDATE_HANDLER_APPLY_REBOOT_FAILURE_MAX_RETRIES_EXCEEDED = 806355714 (0x30100302) */
+ #define ADUC_ERC_SWUPDATE_HANDLER_APPLY_REBOOT_FAILURE_MAX_RETRIES_EXCEEDED 0x30100302
  
- #define ADUC_ERROR_CURL_DOWNLOADER_EXTERNAL_FAILURE(exitCode) MAKE_ADUC_EXTENDEDRESULTCODE_FOR_COMPONENT_ADUC_CONTENT_DOWNLOADER_CURL_DOWNLOADER((0x1000 + exitCode))
++/** Update validation on the new boot partition failed; rebooted to the old boot partition | ADUC_ERC_SWUPDATE_HANDLER_INSTALL_FAILURE_VALIDATION = 806355744 (0x30100320) */
++#define ADUC_ERC_SWUPDATE_HANDLER_INSTALL_FAILURE_VALIDATION 0x30100320
++
+ /** Cancel operation failed | ADUC_ERC_SWUPDATE_HANDLER_CANCEL_FAILURE = 806355968 (0x30100400) */
+ #define ADUC_ERC_SWUPDATE_HANDLER_CANCEL_FAILURE 0x30100400
  
--#endif // ADUC_RESULT_H
-+#endif // ADUC_RESULT_H
-\ No newline at end of file
 diff --git a/src/platform_layers/linux_platform_layer/CMakeLists.txt b/src/platform_layers/linux_platform_layer/CMakeLists.txt
 index 40d57d15..000e5309 100644
 --- a/src/platform_layers/linux_platform_layer/CMakeLists.txt
@@ -1466,8 +1628,39 @@ index b1c9ee0c..057a483a 100644
      {
          Log_Error("statvfs failed, error: %d", errno);
          return nullptr;
+diff --git a/src/utils/apiproto_utils/src/apiproto.c b/src/utils/apiproto_utils/src/apiproto.c
+index 07ef0759..bdf9dd88 100644
+--- a/src/utils/apiproto_utils/src/apiproto.c
++++ b/src/utils/apiproto_utils/src/apiproto.c
+@@ -73,7 +73,7 @@ ssize_t msg_send_req(int fd, const ApiWireRequestMsg* msg)
+             return -1;
+         }
+         Log_Debug("msg_send_req: wrote %zd bytes of data", nbw);
+-        return sizeof(uint16_t) * 3 + nbw;
++        return (ssize_t)(sizeof(uint16_t) * 3) + nbw;
+     }
+     Log_Debug("msg_send_req: wrote %zd bytes of data", bytes_written);
+     return sizeof(uint16_t) * 3;
+@@ -142,7 +142,7 @@ ssize_t msg_recv_req(int fd, ApiWireRequestMsg* out_msg)
+             return wait_res;
+         }
+ 
+-        br = read(fd, ((char*)header_buf) + bytes_read_total, (MSG_HDR_LEN)-bytes_read_total);
++        br = read(fd, ((char*)header_buf) + bytes_read_total, MSG_HDR_LEN - (size_t)bytes_read_total);
+         if (br < 0)
+         {
+             if (errno == EINTR)
+@@ -285,7 +285,7 @@ ssize_t msg_recv_resp(int fd, ApiWireResponseMsg* out_msg)
+     // Now read without select in loop - data is available
+     while (total_bytes_read < (ssize_t)(RESP_MSG_READ_BUF_SIZE) && retries < MAX_RETRIES)
+     {
+-        bytes_read = read(fd, read_buf + total_bytes_read, RESP_MSG_READ_BUF_SIZE - total_bytes_read);
++        bytes_read = read(fd, read_buf + total_bytes_read, RESP_MSG_READ_BUF_SIZE - (size_t)total_bytes_read);
+         if (bytes_read < 0)
+         {
+             if (errno == EINTR || errno == EAGAIN || errno == EWOULDBLOCK)
 diff --git a/src/utils/c_utils/src/string_c_utils.c b/src/utils/c_utils/src/string_c_utils.c
-index bb5445d7..abeb5b2e 100644
+index a7570a17..3e05ebde 100644
 --- a/src/utils/c_utils/src/string_c_utils.c
 +++ b/src/utils/c_utils/src/string_c_utils.c
 @@ -45,7 +45,7 @@ bool LoadBufferWithFileContents(const char* filePath, char* strBuffer, const siz
@@ -1493,10 +1686,10 @@ index dba6c64e..cb25857d 100644
  //
  // HTTP Functions
 diff --git a/src/utils/extension_utils/src/extension_utils.c b/src/utils/extension_utils/src/extension_utils.c
-index 4339770d..ac41f5fc 100644
+index bc3184ae..d256c051 100644
 --- a/src/utils/extension_utils/src/extension_utils.c
 +++ b/src/utils/extension_utils/src/extension_utils.c
-@@ -265,7 +265,7 @@ static bool RegisterHandlerExtension(
+@@ -267,7 +267,7 @@ static bool RegisterHandlerExtension(
          goto done;
      }
  
@@ -1505,7 +1698,7 @@ index 4339770d..ac41f5fc 100644
      if (!ADUC_HashUtils_GetFileHash(handlerFilePath, SHA256, &hash))
      {
          goto done;
-@@ -274,7 +274,7 @@ static bool RegisterHandlerExtension(
+@@ -276,7 +276,7 @@ static bool RegisterHandlerExtension(
      content = STRING_construct_sprintf(
          "{\n"
          "   \"fileName\":\"%s\",\n"
@@ -1514,7 +1707,7 @@ index 4339770d..ac41f5fc 100644
          "   \"hashes\": {\n"
          "        \"sha256\":\"%s\"\n"
          "   },\n"
-@@ -483,7 +483,7 @@ bool RegisterExtension(const char* extensionDir, const char* extensionFilePath)
+@@ -485,7 +485,7 @@ bool RegisterExtension(const char* extensionDir, const char* extensionFilePath)
          goto done;
      }
  
@@ -1523,7 +1716,7 @@ index 4339770d..ac41f5fc 100644
  
      if (!ADUC_HashUtils_GetFileHash(extensionFilePath, SHA256, &hash))
      {
-@@ -493,7 +493,7 @@ bool RegisterExtension(const char* extensionDir, const char* extensionFilePath)
+@@ -495,7 +495,7 @@ bool RegisterExtension(const char* extensionDir, const char* extensionFilePath)
      content = STRING_construct_sprintf(
          "{\n"
          "   \"fileName\":\"%s\",\n"

--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
@@ -888,7 +888,7 @@ index 00000000..8ea0cf2a
 +#endif // ADUC_SWUPDATECONSENT_HANDLER_HPP
 diff --git a/src/extensions/step_handlers/swupdate_consent_handler/src/swupdate_consent_handler.cpp b/src/extensions/step_handlers/swupdate_consent_handler/src/swupdate_consent_handler.cpp
 new file mode 100644
-index 00000000..874fb3a5
+index 00000000..c85a13c9
 --- /dev/null
 +++ b/src/extensions/step_handlers/swupdate_consent_handler/src/swupdate_consent_handler.cpp
 @@ -0,0 +1,598 @@
@@ -1368,7 +1368,7 @@ index 00000000..874fb3a5
 +                Log_Info("cancel requested while waiting for user consent");
 +                CleanConsentRequestJsonFile();
 +                workflow_free_string(installedCriteria_workflow);
-+                return Cancel(workflowData);
++                return ADUC_Result{ ADUC_Result_Failure_Cancelled };
 +            }
 +
 +            if (true == UserConsentAgreed(version))

--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
@@ -1819,6 +1819,19 @@ index bc3184ae..d256c051 100644
          "   \"hashes\": {\n"
          "        \"sha256\":\"%s\"\n"
          "   }\n"
+diff --git a/src/utils/timer_utils/src/timer.c b/src/utils/timer_utils/src/timer.c
+index 899f5ff5..ca35cabe 100644
+--- a/src/utils/timer_utils/src/timer.c
++++ b/src/utils/timer_utils/src/timer.c
+@@ -170,7 +170,7 @@ int AducTimer_Start(AducTimer* t, unsigned w)
+ 
+     pthread_mutex_lock(&t->mut);
+     _reset(t);
+-    t->waitTimeMs = w;
++    t->waitTimeMs = (time_t)w;
+     clock_gettime(CLOCK_MONOTONIC, &t->startTime);
+     if (w != 0 && t->updateIntervalMs != 0) // use zero if want to manually update pump the timer
+     {
 diff --git a/src/utils/workflow_utils/src/workflow_utils.c b/src/utils/workflow_utils/src/workflow_utils.c
 index 5d44850f..fcea1f32 100644
 --- a/src/utils/workflow_utils/src/workflow_utils.c

--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
@@ -1819,3 +1819,98 @@ index bc3184ae..d256c051 100644
          "   \"hashes\": {\n"
          "        \"sha256\":\"%s\"\n"
          "   }\n"
+diff --git a/src/utils/workflow_utils/src/workflow_utils.c b/src/utils/workflow_utils/src/workflow_utils.c
+index 5d44850f..fcea1f32 100644
+--- a/src/utils/workflow_utils/src/workflow_utils.c
++++ b/src/utils/workflow_utils/src/workflow_utils.c
+@@ -2910,6 +2910,18 @@ bool workflow_transfer_data(ADUC_WorkflowHandle targetHandle, ADUC_WorkflowHandl
+         return false;
+     }
+ 
++    // The target's step children were parsed from its previous manifest. Free
++    // them while that manifest is still in place so they get rebuilt from the
++    // source manifest. Without this a replacement keeps the previous
++    // deployment's steps (stale installedCriteria and a leftover cancel
++    // request), because the step count is unchanged and the rebuild guard in
++    // PrepareStepsWorkflowDataObject is skipped.
++    while (workflow_get_children_count(targetHandle) > 0)
++    {
++        ADUC_WorkflowHandle child = workflow_remove_child(targetHandle, 0);
++        workflow_free(child);
++    }
++
+     // Transfer over the parsed JSON objects
+     wfTarget->UpdateActionObject = wfSource->UpdateActionObject;
+     wfSource->UpdateActionObject = NULL;
+diff --git a/src/utils/workflow_utils/tests/workflow_utils_ut.cpp b/src/utils/workflow_utils/tests/workflow_utils_ut.cpp
+index 74feb30b..0fa9e6c8 100644
+--- a/src/utils/workflow_utils/tests/workflow_utils_ut.cpp
++++ b/src/utils/workflow_utils/tests/workflow_utils_ut.cpp
+@@ -17,6 +17,9 @@
+ using Catch::Matchers::Equals;
+ 
+ #include <parson.h>
++#include <cstdlib>
++#include <filesystem>
++#include <fstream>
+ #include <sstream>
+ #include <string>
+ 
+@@ -875,3 +878,57 @@ TEST_CASE("workflow manifest and inode helper APIs")
+ 
+     workflow_free(handle);
+ }
++
++TEST_CASE("workflow_transfer_data drops stale children")
++{
++    // A replacement transfers the incoming workflow's parsed data into the
++    // current handle. The current handle still holds step children parsed from
++    // its previous manifest; those must be dropped so they get rebuilt from the
++    // new manifest (otherwise the replacement runs with the old steps).
++    // workflow_transfer_data needs a config instance to resolve the downloads
++    // folder, so provide a minimal du-config.json.
++    std::filesystem::path cfgDir = std::filesystem::temp_directory_path() / "wfut_transfer_cfg";
++    std::filesystem::create_directories(cfgDir);
++    std::ofstream(cfgDir / "du-config.json") << R"({
++        "schemaVersion": "1.0",
++        "aduShellTrustedUsers": [ "adu" ],
++        "manufacturer": "contoso",
++        "model": "espresso-v1",
++        "agents": [ {
++            "name": "main", "runas": "adu",
++            "connectionSource": { "connectionType": "string", "connectionData": "HostName=x;DeviceId=y;SharedAccessKey=z" },
++            "manufacturer": "contoso", "model": "espresso-v1"
++        } ]
++    })";
++    setenv("ADUC_CONF_FOLDER", cfgDir.c_str(), 1);
++
++    ADUC_WorkflowHandle target = nullptr;
++    ADUC_Result result = workflow_init(action_parent_update, false /* validateManifest */, &target);
++    REQUIRE(IsAducResultCodeSuccess(result.ResultCode));
++
++    // Simulate steps parsed from the previous manifest.
++    for (int i = 0; i < 2; i++)
++    {
++        ADUC_WorkflowHandle child = nullptr;
++        REQUIRE(IsAducResultCodeSuccess(workflow_init(action_child_update_0, false, &child).ResultCode));
++        REQUIRE(workflow_insert_child(target, -1, child));
++    }
++    REQUIRE(workflow_get_children_count(target) == 2);
++
++    ADUC_WorkflowHandle source = nullptr;
++    REQUIRE(IsAducResultCodeSuccess(workflow_init(action_parent_update, false, &source).ResultCode));
++
++    REQUIRE(workflow_transfer_data(target, source));
++
++    // Stale children gone; they will be rebuilt from the transferred manifest.
++    CHECK(workflow_get_children_count(target) == 0);
++
++    // Manifest was transferred from the source.
++    char* updateId = workflow_get_expected_update_id_string(target);
++    REQUIRE(updateId != nullptr);
++    CHECK(strstr(updateId, "Virtual-Vacuum") != nullptr);
++    workflow_free_string(updateId);
++
++    workflow_free(source);
++    workflow_free(target);
++}

--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
@@ -366,7 +366,7 @@ index 292f84da..17a51a53 100644
  
  TEST_CASE("Common task handles unsupported action path")
 diff --git a/src/adu_workflow/src/agent_workflow.c b/src/adu_workflow/src/agent_workflow.c
-index 524747b7..38c7e70f 100644
+index 524747b7..d8156d0c 100644
 --- a/src/adu_workflow/src/agent_workflow.c
 +++ b/src/adu_workflow/src/agent_workflow.c
 @@ -38,6 +38,10 @@
@@ -426,28 +426,18 @@ index 524747b7..38c7e70f 100644
      if (currentWorkflowData == NULL)
      {
          Log_Info("No update content. Ignoring.");
-@@ -614,11 +657,17 @@ void ADUC_Workflow_HandlePropertyUpdate(
+@@ -614,6 +657,11 @@ void ADUC_Workflow_HandlePropertyUpdate(
  
                      Log_Debug("deferral not needed. Processing '%s' now", workflow_peek_id(nextWorkflow));
  
--                    workflow_transfer_data(
--                        currentWorkflowData->WorkflowHandle /* wfTarget */, nextWorkflow /* wfSource */);
-+                    // We don't use reuse currentWorkflowData.
-+                    // currentWorkflow is current resp. **old** workflow before cloud updated with nextWorkflow (**current** incoming).
-+                    // workflow_transfer_data only works if version to update is equal in currentWorkflow and nextWorkflow.
-+                    // Thus we disable copying transfer data between workflows and don't use currentWorkflow (**old**).
-+                    // Thus we use nextWorkflow (**current** incoming).
++                    // Transfer the incoming manifest into the current handle and process it.
++                    // transfer_data rebuilds the step children from the new manifest (issue
++                    // #511), so a replacement with a differing version no longer reuses the
++                    // previous deployment's steps. This keeps a single replacement path shared
++                    // with the deferred case (workflow_update_for_replacement).
+                     workflow_transfer_data(
+                         currentWorkflowData->WorkflowHandle /* wfTarget */, nextWorkflow /* wfSource */);
  
--                    ADUC_Workflow_HandleUpdateAction(currentWorkflowData);
--                    goto done;
-+                    // workflow_transfer_data(
-+                    //     currentWorkflowData->WorkflowHandle /* wfTarget */, nextWorkflow /* wfSource */);
-+
-+                    // ADUC_Workflow_HandleUpdateAction(currentWorkflowData);
-+                    // goto done;
-                 }
- 
-                 // Fall through to handle new workflow
 diff --git a/src/agent/src/health_management.c b/src/agent/src/health_management.c
 index 38ad9ea5..b32dcc33 100644
 --- a/src/agent/src/health_management.c
@@ -1833,10 +1823,10 @@ index 899f5ff5..ca35cabe 100644
      if (w != 0 && t->updateIntervalMs != 0) // use zero if want to manually update pump the timer
      {
 diff --git a/src/utils/workflow_utils/src/workflow_utils.c b/src/utils/workflow_utils/src/workflow_utils.c
-index 5d44850f..fcea1f32 100644
+index 5d44850f..34be0bc9 100644
 --- a/src/utils/workflow_utils/src/workflow_utils.c
 +++ b/src/utils/workflow_utils/src/workflow_utils.c
-@@ -2910,6 +2910,18 @@ bool workflow_transfer_data(ADUC_WorkflowHandle targetHandle, ADUC_WorkflowHandl
+@@ -2910,6 +2910,25 @@ bool workflow_transfer_data(ADUC_WorkflowHandle targetHandle, ADUC_WorkflowHandl
          return false;
      }
  
@@ -1852,11 +1842,18 @@ index 5d44850f..fcea1f32 100644
 +        workflow_free(child);
 +    }
 +
++    // Free the target's own parsed objects before overwriting the pointers
++    // below, so replacing a handle that already holds a manifest does not leak
++    // the replaced deployment's objects.
++    _workflow_free_updateaction(targetHandle);
++    _workflow_free_updatemanifest(targetHandle);
++    _workflow_free_properties(targetHandle);
++
      // Transfer over the parsed JSON objects
      wfTarget->UpdateActionObject = wfSource->UpdateActionObject;
      wfSource->UpdateActionObject = NULL;
 diff --git a/src/utils/workflow_utils/tests/workflow_utils_ut.cpp b/src/utils/workflow_utils/tests/workflow_utils_ut.cpp
-index 74feb30b..0fa9e6c8 100644
+index 74feb30b..6094b50d 100644
 --- a/src/utils/workflow_utils/tests/workflow_utils_ut.cpp
 +++ b/src/utils/workflow_utils/tests/workflow_utils_ut.cpp
 @@ -17,6 +17,9 @@
@@ -1869,7 +1866,7 @@ index 74feb30b..0fa9e6c8 100644
  #include <sstream>
  #include <string>
  
-@@ -875,3 +878,57 @@ TEST_CASE("workflow manifest and inode helper APIs")
+@@ -875,3 +878,108 @@ TEST_CASE("workflow manifest and inode helper APIs")
  
      workflow_free(handle);
  }
@@ -1923,6 +1920,57 @@ index 74feb30b..0fa9e6c8 100644
 +    REQUIRE(updateId != nullptr);
 +    CHECK(strstr(updateId, "Virtual-Vacuum") != nullptr);
 +    workflow_free_string(updateId);
++
++    workflow_free(source);
++    workflow_free(target);
++}
++
++TEST_CASE("workflow_transfer_data adopts the replacement manifest")
++{
++    // A replacement with a different update than the one on the handle must end
++    // up running the incoming manifest, not the replaced one. This is what the
++    // non-deferred replacement path in ADUC_Workflow_HandlePropertyUpdate relies
++    // on: it transfers the incoming workflow into the current handle and expects
++    // the new manifest (and its installedCriteria) to take effect.
++    std::filesystem::path cfgDir = std::filesystem::temp_directory_path() / "wfut_transfer_replace_cfg";
++    std::filesystem::create_directories(cfgDir);
++    std::ofstream(cfgDir / "du-config.json") << R"({
++        "schemaVersion": "1.0",
++        "aduShellTrustedUsers": [ "adu" ],
++        "manufacturer": "contoso",
++        "model": "espresso-v1",
++        "agents": [ {
++            "name": "main", "runas": "adu",
++            "connectionSource": { "connectionType": "string", "connectionData": "HostName=x;DeviceId=y;SharedAccessKey=z" },
++            "manufacturer": "contoso", "model": "espresso-v1"
++        } ]
++    })";
++    setenv("ADUC_CONF_FOLDER", cfgDir.c_str(), 1);
++
++    // Target = the update already on the handle (contoso-virtual-motors 1.1),
++    // with a stale step child parsed from its manifest.
++    ADUC_WorkflowHandle target = nullptr;
++    REQUIRE(IsAducResultCodeSuccess(workflow_init(action_child_update_0, false, &target).ResultCode));
++    ADUC_WorkflowHandle staleChild = nullptr;
++    REQUIRE(IsAducResultCodeSuccess(workflow_init(action_child_update_0, false, &staleChild).ResultCode));
++    REQUIRE(workflow_insert_child(target, -1, staleChild));
++    REQUIRE(workflow_get_children_count(target) == 1);
++
++    // Source = the incoming replacement (Virtual-Vacuum 20.0).
++    ADUC_WorkflowHandle source = nullptr;
++    REQUIRE(IsAducResultCodeSuccess(workflow_init(action_parent_update, false, &source).ResultCode));
++
++    REQUIRE(workflow_transfer_data(target, source));
++
++    // The target now carries the incoming manifest, not the replaced one.
++    char* updateId = workflow_get_expected_update_id_string(target);
++    REQUIRE(updateId != nullptr);
++    CHECK(strstr(updateId, "Virtual-Vacuum") != nullptr);
++    CHECK(strstr(updateId, "contoso-virtual-motors") == nullptr);
++    workflow_free_string(updateId);
++
++    // Stale children were dropped so they rebuild from the new manifest.
++    CHECK(workflow_get_children_count(target) == 0);
 +
 +    workflow_free(source);
 +    workflow_free(target);

--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
@@ -72,7 +72,7 @@ index fbc6546b..b16fc426 100644
 +echo "ADU Reboot Wrapper: Agent ready after ${elapsed}s; adu-shell will reboot"
 +exit 0
 diff --git a/src/adu-shell/src/common_tasks.cpp b/src/adu-shell/src/common_tasks.cpp
-index 770f8bd4..a78da85a 100644
+index 770f8bd4..c09f286f 100644
 --- a/src/adu-shell/src/common_tasks.cpp
 +++ b/src/adu-shell/src/common_tasks.cpp
 @@ -5,10 +5,19 @@
@@ -139,7 +139,7 @@ index 770f8bd4..a78da85a 100644
 +    // reboot(2) does not flush the page cache; sync first, as /sbin/reboot does.
 +    sync();
 +    Log_Info("Calling reboot(RB_AUTOBOOT).");
-+    if (::reboot(RB_AUTOBOOT) != 0)
++    if (ADUC_SystemReboot(RB_AUTOBOOT) != 0)
 +    {
 +        const int saved_errno = errno;
 +        Log_Error("reboot(RB_AUTOBOOT) failed (errno: %d)", saved_errno);
@@ -317,7 +317,7 @@ index adbd4446..95b2d062 100644
      if (filePermissionsChanged)
      {
 diff --git a/src/adu-shell/tests/adushell_ut.cpp b/src/adu-shell/tests/adushell_ut.cpp
-index 292f84da..17a51a53 100644
+index 292f84da..30a825f0 100644
 --- a/src/adu-shell/tests/adushell_ut.cpp
 +++ b/src/adu-shell/tests/adushell_ut.cpp
 @@ -14,8 +14,10 @@
@@ -327,41 +327,100 @@ index 292f84da..17a51a53 100644
 +#include <cerrno>
  #include <chrono>
  #include <filesystem>
-+#include <unistd.h> // geteuid
++#include <sys/reboot.h> // RB_AUTOBOOT
  #include <fstream>
  #include <string>
  #include <sys/stat.h>
-@@ -229,17 +231,31 @@ TEST_CASE("AptGet rollback appends output from cleanup phase")
+@@ -41,6 +43,26 @@ struct LaunchCapture
+ 
+ LaunchCapture g_launchCapture;
+ 
++// Captures ADUC_SystemReboot calls so the reboot path can be tested without
++// actually rebooting (and so it runs in CI regardless of privilege).
++struct RebootCapture
++{
++    int callCount{ 0 };
++    int howto{ 0 };
++    int returnValue{ 0 }; // value ADUC_SystemReboot returns to the caller
++    int errnoValue{ 0 }; // errno set when returnValue is non-zero
++
++    void Reset()
++    {
++        callCount = 0;
++        howto = 0;
++        returnValue = 0;
++        errnoValue = 0;
++    }
++};
++
++RebootCapture g_rebootCapture;
++
+ // Tests in this file create, chmod/chown, and delete script files at runtime.
+ // They must write to a writable scratch directory under the build's configurable
+ // work folder (ADU_SHELL_TEST_TMP_DIR is derived from ADUC_TMP_DIR_PATH / the
+@@ -107,6 +129,17 @@ int ADUC_LaunchChildProcess(const std::string& command, std::vector<std::string>
+     return g_launchCapture.exitCode;
+ }
+ 
++int ADUC_SystemReboot(int howto)
++{
++    g_rebootCapture.callCount++;
++    g_rebootCapture.howto = howto;
++    if (g_rebootCapture.returnValue != 0)
++    {
++        errno = g_rebootCapture.errnoValue;
++    }
++    return g_rebootCapture.returnValue;
++}
++
+ TEST_CASE("ADUShellTaskResult defaults to success and empty output")
+ {
+     ADUShellTaskResult result;
+@@ -229,17 +262,42 @@ TEST_CASE("AptGet rollback appends output from cleanup phase")
      CHECK(taskResult.Output() == "phasephase");
  }
  
 -TEST_CASE("Common reboot task dispatches reboot command")
-+TEST_CASE("Common reboot task waits via the reboot wrapper, then calls reboot syscall directly")
++TEST_CASE("Common reboot task waits via the reboot wrapper, then calls reboot syscall")
  {
-+    // Reboot() calls the real reboot(RB_AUTOBOOT) syscall (only the child-process
-+    // launch is mocked). Run as root in the initial PID namespace it would reboot
-+    // the host, so skip when privileged. The success path cannot be tested safely.
-+    if (geteuid() == 0)
-+    {
-+        SKIP("Reboot() calls the real reboot(2) syscall; skipping as root to avoid rebooting the host");
-+    }
-+
++    // reboot(2) is mocked via ADUC_SystemReboot, so the reboot path runs in CI
++    // without rebooting the machine and regardless of privilege.
      g_launchCapture.Reset();
++    g_rebootCapture.Reset();
  
      ADUShell_LaunchArguments launchArgs{};
  
-     auto taskResult = Adu::Shell::Tasks::Common::Reboot(launchArgs);
+-    auto taskResult = Adu::Shell::Tasks::Common::Reboot(launchArgs);
++    SECTION("Successful reboot launches the wrapper then calls reboot(RB_AUTOBOOT)")
++    {
++        g_rebootCapture.returnValue = 0;
  
 -    CHECK(taskResult.ExitStatus() == 0);
-+    // The only child process launched is the wrapper, which waits for the
-+    // agent to finish caching and reporting before the reboot proceeds.
-     CHECK(g_launchCapture.command == "/usr/lib/adu/adu-reboot-wrapper.sh");
-     REQUIRE(g_launchCapture.args.size() == 0);
+-    CHECK(g_launchCapture.command == "/usr/lib/adu/adu-reboot-wrapper.sh");
+-    REQUIRE(g_launchCapture.args.size() == 0);
++        auto taskResult = Adu::Shell::Tasks::Common::Reboot(launchArgs);
 +
-+    // reboot(2) fails without privilege here; the code maps the failure to a
-+    // non-zero exit status (errno). Assert only that, not a specific errno,
-+    // which depends on the sandbox.
-+    CHECK(taskResult.ExitStatus() != 0);
++        // The only child process launched is the wrapper, which waits for the
++        // agent to finish caching and reporting before the reboot proceeds.
++        CHECK(g_launchCapture.command == "/usr/lib/adu/adu-reboot-wrapper.sh");
++        REQUIRE(g_launchCapture.args.size() == 0);
++
++        // The reboot itself is the in-process reboot(2) syscall.
++        CHECK(g_rebootCapture.callCount == 1);
++        CHECK(g_rebootCapture.howto == RB_AUTOBOOT);
++        CHECK(taskResult.ExitStatus() == 0);
++    }
++
++    SECTION("Failed reboot maps errno to the exit status")
++    {
++        g_rebootCapture.returnValue = -1;
++        g_rebootCapture.errnoValue = EPERM;
++
++        auto taskResult = Adu::Shell::Tasks::Common::Reboot(launchArgs);
++
++        CHECK(g_rebootCapture.callCount == 1);
++        CHECK(taskResult.ExitStatus() == EPERM);
++    }
  }
  
  TEST_CASE("Common task handles unsupported action path")
@@ -1809,6 +1868,49 @@ index bc3184ae..d256c051 100644
          "   \"hashes\": {\n"
          "        \"sha256\":\"%s\"\n"
          "   }\n"
+diff --git a/src/utils/process_utils/inc/aduc/process_utils.hpp b/src/utils/process_utils/inc/aduc/process_utils.hpp
+index ba9f6fa8..52df3e3c 100644
+--- a/src/utils/process_utils/inc/aduc/process_utils.hpp
++++ b/src/utils/process_utils/inc/aduc/process_utils.hpp
+@@ -45,6 +45,17 @@ int ADUC_LaunchChildProcess(const std::string& command, std::vector<std::string>
+ int ADUC_LaunchChildProcess(
+     const std::string& command, std::vector<std::string> args, std::vector<std::string>& output);
+ 
++/**
++ * @brief Wrapper around the reboot(2) syscall.
++ *
++ * Exists as a seam so unit tests can intercept the reboot request instead of
++ * actually rebooting the machine.
++ *
++ * @param howto The reboot command, e.g. RB_AUTOBOOT (see sys/reboot.h).
++ * @return 0 on success; -1 with errno set on failure.
++ */
++int ADUC_SystemReboot(int howto);
++
+ /**
+  * @brief Ensure that the effective group of the process is the given group (or is root).
+  * @remark This function is not thread-safe if called with the defaults for the optional args.
+diff --git a/src/utils/process_utils/src/process_utils.cpp b/src/utils/process_utils/src/process_utils.cpp
+index 76484acf..83f727ac 100644
+--- a/src/utils/process_utils/src/process_utils.cpp
++++ b/src/utils/process_utils/src/process_utils.cpp
+@@ -13,6 +13,7 @@
+ #include <stdio.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include <sys/reboot.h> // reboot
+ #include <sys/types.h>
+ 
+ #include <aduc/c_utils.h>
+@@ -322,3 +323,8 @@ bool VerifyProcessEffectiveUser(
+     }
+     return isTrusted;
+ }
++
++int ADUC_SystemReboot(int howto)
++{
++    return reboot(howto);
++}
 diff --git a/src/utils/timer_utils/src/timer.c b/src/utils/timer_utils/src/timer.c
 index 899f5ff5..ca35cabe 100644
 --- a/src/utils/timer_utils/src/timer.c

--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
@@ -48,42 +48,54 @@ index 1871bae9..50bf1987 100755
  compiler_packages=('gcc' 'g++')
  
 diff --git a/src/adu-shell/scripts/adu-reboot-wrapper.sh b/src/adu-shell/scripts/adu-reboot-wrapper.sh
-index fbc6546b..d690ea1b 100644
+index fbc6546b..b16fc426 100644
 --- a/src/adu-shell/scripts/adu-reboot-wrapper.sh
 +++ b/src/adu-shell/scripts/adu-reboot-wrapper.sh
-@@ -35,10 +35,12 @@ done
+@@ -34,11 +34,14 @@ done
+ # Cleanup any remaining lock
  rm -f "$LOCK_FILE" 2> /dev/null
  
++# This wrapper only waits for the agent; adu-shell performs the actual reboot
++# after this script returns. Report the outcome via the exit code so the caller
++# can tell a timeout (agent may not have finished) from a clean handshake:
++#   0 = agent signalled ready, 2 = wait timed out.
  if [ $elapsed -ge "$TIMEOUT" ]; then
 -    echo "ADU Reboot Wrapper: Timeout reached after ${elapsed}s, forcing reboot"
-+    echo "ADU Reboot Wrapper: Timeout reached after ${elapsed}s; adu-shell will reboot"
- else
+-else
 -    echo "ADU Reboot Wrapper: Agent ready after ${elapsed}s, proceeding with reboot"
-+    echo "ADU Reboot Wrapper: Agent ready after ${elapsed}s; adu-shell will reboot"
++    echo "ADU Reboot Wrapper: Timeout reached after ${elapsed}s; adu-shell will reboot"
++    exit 2
  fi
  
 -# Perform actual reboot
 -exec /sbin/reboot "$@"
-+# This wrapper only waits for the agent. adu-shell performs the actual reboot
-+# via the reboot(2) syscall (CAP_SYS_BOOT) after this script returns, so no
-+# privileged reboot child process is spawned here.
++echo "ADU Reboot Wrapper: Agent ready after ${elapsed}s; adu-shell will reboot"
 +exit 0
 diff --git a/src/adu-shell/src/common_tasks.cpp b/src/adu-shell/src/common_tasks.cpp
-index 770f8bd4..11fc68ad 100644
+index 770f8bd4..a78da85a 100644
 --- a/src/adu-shell/src/common_tasks.cpp
 +++ b/src/adu-shell/src/common_tasks.cpp
-@@ -5,6 +5,10 @@
+@@ -5,10 +5,19 @@
   * @copyright Copyright (c) Microsoft Corporation.
   * Licensed under the MIT License.
   */
 +#include <cerrno>
 +#include <stdlib.h> // for getenv
 +#include <sys/reboot.h>
++#include <unistd.h> // sync
 +
  #include "common_tasks.hpp"
  #include "aduc/process_utils.hpp"
  
-@@ -25,26 +29,55 @@ namespace Common
+ #include <unordered_map>
++
++// adu-reboot-wrapper.sh returns this when the wait for the agent timed out,
++// as opposed to 0 when the agent signalled it is ready.
++#define ADU_REBOOT_WRAPPER_EXIT_TIMEOUT 2
+ namespace Adu
+ {
+ namespace Shell
+@@ -25,29 +34,70 @@ namespace Common
   */
  ADUShellTaskResult Reboot(const ADUShell_LaunchArguments& /*launchArgs*/)
  {
@@ -93,13 +105,10 @@ index 770f8bd4..11fc68ad 100644
 -    // The agent creates /var/run/adu-agent-reboot.lock before calling this
 -    // and removes it after caching and reporting status to cloud
 +
-+    // Wait for the agent to finish caching updates and reporting status to the
-+    // cloud before we reboot. The agent holds /var/run/adu-agent-reboot.lock
-+    // while it prepares; the wrapper polls until the lock is gone (or a timeout)
-+    // and then returns. This preserves the sandbox so downloads can resume after
-+    // restart. The wrapper only waits — it does not reboot. The reboot itself is
-+    // the in-process reboot(2) syscall below, using adu-shell's CAP_SYS_BOOT
-+    // capability, so no privileged child process is spawned for it.
++    // Wait for the agent to finish caching updates and reporting to the cloud
++    // before rebooting, so the sandbox survives the restart and downloads can
++    // resume. adu-reboot-wrapper.sh polls the agent's lock file and returns; it
++    // does not reboot. The reboot is the in-process reboot(2) syscall below.
      std::vector<std::string> args{};
      std::string output;
 -    int exitCode = ADUC_LaunchChildProcess("/usr/lib/adu/adu-reboot-wrapper.sh", args, output);
@@ -108,25 +117,35 @@ index 770f8bd4..11fc68ad 100644
 +    int waitExitCode = ADUC_LaunchChildProcess("/usr/lib/adu/adu-reboot-wrapper.sh", args, output);
 +    if (!output.empty())
 +    {
-+        Log_Info(output.c_str());
++        Log_Info("%s", output.c_str());
 +    }
-+    if (waitExitCode != 0)
++    if (waitExitCode == ADU_REBOOT_WRAPPER_EXIT_TIMEOUT)
      {
 -        Log_Info("Reboot wrapper completed successfully.");
-+        Log_Warn("Reboot wrapper returned %d; proceeding with reboot anyway.", waitExitCode);
++        // Reboot anyway (blocking would strand a half-applied update), but the
++        // agent may not have finished, so download-resume can be lost.
++        Log_Warn("Reboot wrapper timed out waiting for the agent; rebooting anyway.");
      }
 -    else
-+
-+    Log_Info("Calling reboot(RB_AUTOBOOT) directly using CAP_SYS_BOOT capability.");
-+    if (::reboot(RB_AUTOBOOT) != 0)
++    else if (waitExitCode != 0)
      {
 -        Log_Error("Reboot wrapper failed, exit code: %d", exitCode);
-+        const int saved_errno = errno;
-+        Log_Error("reboot(RB_AUTOBOOT) failed (errno: %d)", saved_errno);
-+        taskResult.SetExitStatus(saved_errno);
++        // The wrapper did not run (missing or exec failure): the wait barrier
++        // was skipped entirely.
++        Log_Error("Reboot wrapper failed to run (exit %d); reboot barrier skipped.", waitExitCode);
      }
  
 -    taskResult.SetExitStatus(exitCode);
++    // reboot(2) does not flush the page cache; sync first, as /sbin/reboot does.
++    sync();
++    Log_Info("Calling reboot(RB_AUTOBOOT).");
++    if (::reboot(RB_AUTOBOOT) != 0)
++    {
++        const int saved_errno = errno;
++        Log_Error("reboot(RB_AUTOBOOT) failed (errno: %d)", saved_errno);
++        taskResult.SetExitStatus(saved_errno);
++    }
++
 +    return taskResult;
 +}
 +
@@ -138,23 +157,32 @@ index 770f8bd4..11fc68ad 100644
 +    std::vector<std::string> args{ "log", reason };
 +    std::string output;
 +    const char* script;
- 
-+    Log_Info("Launching child process to record reboot reason (\"%s\")", reason);
 +
++    Log_Info("Launching child process to record reboot reason (\"%s\")", reason);
+ 
 +    script = getenv("OMNECT_LOG_REBOOT_REASON_SCRIPT");
 +    if (nullptr == script)
 +    {
 +        script = OMNECT_DEFAULT_LOG_REBOOT_REASON_SCRIPT;
 +    }
-+    taskResult.SetExitStatus(ADUC_LaunchChildProcess(script, args, output));
++    int exitCode = ADUC_LaunchChildProcess(script, args, output);
++    taskResult.SetExitStatus(exitCode);
      if (!output.empty())
      {
-         Log_Info(output.c_str());
-@@ -81,6 +114,16 @@ ADUShellTaskResult DoCommonTask(const ADUShell_LaunchArguments& launchArgs)
+-        Log_Info(output.c_str());
++        Log_Info("%s", output.c_str());
++    }
++    if (exitCode != 0)
++    {
++        Log_Warn("Recording reboot reason failed (exit %d)", exitCode);
+     }
+     return taskResult;
+ }
+@@ -81,6 +131,16 @@ ADUShellTaskResult DoCommonTask(const ADUShell_LaunchArguments& launchArgs)
          taskResult.SetExitStatus(ADUSHELL_EXIT_UNSUPPORTED);
      }
  
-+    // we're ready now to perform the reboot, so log reboot reason right now
++    // Record the reboot reason before the reboot: reboot(2) does not return.
 +    try
 +    {
 +        DoRebootReason("swupdate");
@@ -221,7 +249,7 @@ index cf1f3bd5..0d715d2b 100644
      ADUC_ConfigInfo_ReleaseInstance(config);
      return ret;
 diff --git a/src/adu-shell/src/script_tasks.cpp b/src/adu-shell/src/script_tasks.cpp
-index adbd4446..50570a60 100644
+index adbd4446..95b2d062 100644
 --- a/src/adu-shell/src/script_tasks.cpp
 +++ b/src/adu-shell/src/script_tasks.cpp
 @@ -49,11 +49,8 @@ ADUShellTaskResult Execute(const ADUShell_LaunchArguments& launchArgs)
@@ -242,7 +270,7 @@ index adbd4446..50570a60 100644
  
 -    // Remember the original permissions and ownership so they can be restored after execution.
 +    // Remember the original permissions so they can be restored after execution.
-+    // omnect intentionally does not change or restore the script ownership (no chown).
++    // omnect intentionally does not touch the script ownership.
      originalMode = st.st_mode & ~S_IFMT;
 -    originalUid = st.st_uid;
 -    originalGid = st.st_gid;
@@ -289,27 +317,38 @@ index adbd4446..50570a60 100644
      if (filePermissionsChanged)
      {
 diff --git a/src/adu-shell/tests/adushell_ut.cpp b/src/adu-shell/tests/adushell_ut.cpp
-index 292f84da..f9e1596a 100644
+index 292f84da..17a51a53 100644
 --- a/src/adu-shell/tests/adushell_ut.cpp
 +++ b/src/adu-shell/tests/adushell_ut.cpp
-@@ -14,6 +14,7 @@
+@@ -14,8 +14,10 @@
  #include <catch2/catch_all.hpp>
  
  #include <atomic>
 +#include <cerrno>
  #include <chrono>
  #include <filesystem>
++#include <unistd.h> // geteuid
  #include <fstream>
-@@ -229,7 +230,7 @@ TEST_CASE("AptGet rollback appends output from cleanup phase")
+ #include <string>
+ #include <sys/stat.h>
+@@ -229,17 +231,31 @@ TEST_CASE("AptGet rollback appends output from cleanup phase")
      CHECK(taskResult.Output() == "phasephase");
  }
  
 -TEST_CASE("Common reboot task dispatches reboot command")
 +TEST_CASE("Common reboot task waits via the reboot wrapper, then calls reboot syscall directly")
  {
++    // Reboot() calls the real reboot(RB_AUTOBOOT) syscall (only the child-process
++    // launch is mocked). Run as root in the initial PID namespace it would reboot
++    // the host, so skip when privileged. The success path cannot be tested safely.
++    if (geteuid() == 0)
++    {
++        SKIP("Reboot() calls the real reboot(2) syscall; skipping as root to avoid rebooting the host");
++    }
++
      g_launchCapture.Reset();
  
-@@ -237,9 +238,15 @@ TEST_CASE("Common reboot task dispatches reboot command")
+     ADUShell_LaunchArguments launchArgs{};
  
      auto taskResult = Adu::Shell::Tasks::Common::Reboot(launchArgs);
  
@@ -319,10 +358,10 @@ index 292f84da..f9e1596a 100644
      CHECK(g_launchCapture.command == "/usr/lib/adu/adu-reboot-wrapper.sh");
      REQUIRE(g_launchCapture.args.size() == 0);
 +
-+    // The reboot itself is the in-process reboot(2) syscall. In the test
-+    // environment (no CAP_SYS_BOOT), reboot(2) returns EPERM. A non-zero exit
-+    // confirms the syscall was attempted and failed gracefully.
-+    CHECK(taskResult.ExitStatus() == EPERM);
++    // reboot(2) fails without privilege here; the code maps the failure to a
++    // non-zero exit status (errno). Assert only that, not a specific errno,
++    // which depends on the sandbox.
++    CHECK(taskResult.ExitStatus() != 0);
  }
  
  TEST_CASE("Common task handles unsupported action path")
@@ -490,7 +529,7 @@ index 89a2523c..563feb37 100644
      case IOTHUB_CLIENT_CONNECTION_UNAUTHENTICATED:
          if (IoTHub_CommunicationManager_CategorizeUnauthenticated(status_reason)
 diff --git a/src/communication_managers/iothub_communication_manager/tests/CMakeLists.txt b/src/communication_managers/iothub_communication_manager/tests/CMakeLists.txt
-index dbd6d5b5..69868fc4 100644
+index dbd6d5b5..f0d96f74 100644
 --- a/src/communication_managers/iothub_communication_manager/tests/CMakeLists.txt
 +++ b/src/communication_managers/iothub_communication_manager/tests/CMakeLists.txt
 @@ -26,8 +26,9 @@ target_link_aziotsharedutil (${PROJECT_NAME} PRIVATE)
@@ -510,9 +549,9 @@ index dbd6d5b5..69868fc4 100644
              libaducpal)
  
 +# Link the MQTT transports last, like the agent target does. They are static
-+# archives that pull umqtt/aziotsharedutil symbols, so their link order is
-+# sensitive; omnect's systemd dependency on iothub_communication_manager shifts
-+# the order enough to break resolution when they are listed earlier.
++# archives that reference umqtt/aziotsharedutil, so on GNU ld they must come
++# after those libs; omnect's systemd dependency on iothub_communication_manager
++# shifts the link order enough to break this when they are listed earlier.
 +target_link_libraries (${PROJECT_NAME}
 +                       PRIVATE iothub_client_mqtt_transport iothub_client_mqtt_ws_transport)
 +
@@ -559,33 +598,89 @@ index 6ce04d11..d238d300 100644
  #include <diagnostics_config_utils.h>
  #include <diagnostics_devicename.h>
 diff --git a/src/diagnostics_component/diagnostics_workflow/tests/diagnostics_workflow_ut.cpp b/src/diagnostics_component/diagnostics_workflow/tests/diagnostics_workflow_ut.cpp
-index b0e6823e..b3e0e5a4 100644
+index b0e6823e..bfb8fab6 100644
 --- a/src/diagnostics_component/diagnostics_workflow/tests/diagnostics_workflow_ut.cpp
 +++ b/src/diagnostics_component/diagnostics_workflow/tests/diagnostics_workflow_ut.cpp
-@@ -429,6 +429,11 @@ TEST_CASE("DiagnosticsWorkflow_GetFilesForComponent")
- // ============================================================================
- TEST_CASE("DiagnosticsWorkflow_UploadFilesForComponent")
- {
-+    // omnect builds without diagnostic_utils::file_upload_utility, so the blob
-+    // upload is stubbed out and always fails. This test exercises the real
-+    // upload path, so skip it.
-+    SKIP("diagnostics blob upload (file_upload_utility) is disabled in omnect");
-+
-     DiagnosticsWorkflowTestHelper helper;
+@@ -520,29 +520,6 @@ TEST_CASE("DiagnosticsWorkflow_UploadFilesForComponent")
+         STRING_delete(comp.componentName);
+     }
  
-     SECTION("NULL fileNames returns Failure")
-@@ -666,6 +671,11 @@ TEST_CASE("DiagnosticsWorkflow_UnInitLogComponentFileNames")
- // ============================================================================
- TEST_CASE("DiagnosticsWorkflow_DiscoverAndUploadLogs")
- {
-+    // omnect builds without diagnostic_utils::file_upload_utility, so the blob
-+    // upload is stubbed out and always fails. This test exercises the real
-+    // upload path, so skip it.
-+    SKIP("diagnostics blob upload (file_upload_utility) is disabled in omnect");
-+
-     DiagnosticsWorkflowTestHelper helper;
+-    SECTION("Successful upload returns Success")
+-    {
+-        g_mock_upload_return = true;
+-
+-        VECTOR_HANDLE fileNames = VECTOR_create(sizeof(STRING_HANDLE));
+-        STRING_HANDLE fileName = STRING_construct("test.log");
+-        VECTOR_push_back(fileNames, &fileName, 1);
+-
+-        DiagnosticsLogComponent comp = {};
+-        comp.componentName = STRING_construct("adu-agent");
+-        comp.logPath = STRING_construct("/var/log/adu");
+-
+-        Diagnostics_Result result =
+-            DiagnosticsWorkflow_UploadFilesForComponent(fileNames, &comp, "device1", "op-123", "https://sas.url/token");
+-        CHECK(result == Diagnostics_Result_Success);
+-        CHECK(g_mock_upload_call_count == 1);
+-
+-        STRING_delete(fileName);
+-        VECTOR_destroy(fileNames);
+-        STRING_delete(comp.componentName);
+-        STRING_delete(comp.logPath);
+-    }
+-
+     SECTION("Upload failure returns UploadFailed")
+     {
+         g_mock_upload_return = false;
+@@ -773,6 +750,49 @@ TEST_CASE("DiagnosticsWorkflow_DiscoverAndUploadLogs")
+         CleanupTestWorkflowData(&data);
+     }
  
-     SECTION("NULL jsonString reports failure")
++}
++
++// ============================================================================
++// The following success paths need a working diagnostics blob upload, which
++// omnect disables (file_upload_utility is stubbed out and always fails). They
++// live in their own skipped test cases so the validation and error-path
++// coverage in the cases above keeps running (a skip in a shared case would
++// mask sibling failures under ctest).
++// ============================================================================
++TEST_CASE("DiagnosticsWorkflow_UploadFilesForComponent upload success (disabled in omnect)")
++{
++    SKIP("diagnostics blob upload (file_upload_utility) is disabled in omnect");
++    DiagnosticsWorkflowTestHelper helper;
++
++    SECTION("Successful upload returns Success")
++    {
++        g_mock_upload_return = true;
++
++        VECTOR_HANDLE fileNames = VECTOR_create(sizeof(STRING_HANDLE));
++        STRING_HANDLE fileName = STRING_construct("test.log");
++        VECTOR_push_back(fileNames, &fileName, 1);
++
++        DiagnosticsLogComponent comp = {};
++        comp.componentName = STRING_construct("adu-agent");
++        comp.logPath = STRING_construct("/var/log/adu");
++
++        Diagnostics_Result result =
++            DiagnosticsWorkflow_UploadFilesForComponent(fileNames, &comp, "device1", "op-123", "https://sas.url/token");
++        CHECK(result == Diagnostics_Result_Success);
++        CHECK(g_mock_upload_call_count == 1);
++
++        STRING_delete(fileName);
++        VECTOR_destroy(fileNames);
++        STRING_delete(comp.componentName);
++        STRING_delete(comp.logPath);
++    }
++}
++
++TEST_CASE("DiagnosticsWorkflow_DiscoverAndUploadLogs upload success (disabled in omnect)")
++{
++    SKIP("diagnostics blob upload (file_upload_utility) is disabled in omnect");
++    DiagnosticsWorkflowTestHelper helper;
++
+     SECTION("Full successful workflow reports Success and stores operation ID")
+     {
+         DiagnosticsWorkflowData data = CreateTestWorkflowData("adu", "/tmp/logs", 1024);
 diff --git a/src/diagnostics_component/utils/CMakeLists.txt b/src/diagnostics_component/utils/CMakeLists.txt
 index 2952f344..811a22f1 100644
 --- a/src/diagnostics_component/utils/CMakeLists.txt
@@ -793,10 +888,10 @@ index 00000000..8ea0cf2a
 +#endif // ADUC_SWUPDATECONSENT_HANDLER_HPP
 diff --git a/src/extensions/step_handlers/swupdate_consent_handler/src/swupdate_consent_handler.cpp b/src/extensions/step_handlers/swupdate_consent_handler/src/swupdate_consent_handler.cpp
 new file mode 100644
-index 00000000..891e09b8
+index 00000000..874fb3a5
 --- /dev/null
 +++ b/src/extensions/step_handlers/swupdate_consent_handler/src/swupdate_consent_handler.cpp
-@@ -0,0 +1,599 @@
+@@ -0,0 +1,598 @@
 +/**
 + * @file swupdate_consent_handler.cpp
 + * @brief Implementation of ContentHandler API for update content swupdate_consent.
@@ -813,7 +908,6 @@ index 00000000..891e09b8
 +#include "aduc/workflow_utils.h"
 +#include <azure_c_shared_utility/threadapi.h> // ThreadAPI_Sleep
 +#include <parson.h>
-+#include <signal.h> // raise()
 +
 +#define ADUC_SWUPDATE_CONSENT_CONF_FILE "/etc/omnect/consent/consent_conf.json"
 +#define ADUC_SWUPDATE_CONSENT_USER_FILE "/etc/omnect/consent/swupdate/user_consent.json"
@@ -1271,10 +1365,10 @@ index 00000000..891e09b8
 +        {
 +            if (workflow_is_cancel_requested(workflowHandle))
 +            {
-+                // see issue: https://github.com/Azure/iot-hub-device-update/issues/511
-+                // Workaround until we get a final fix from MS
-+                Log_Info("Restarting ADU Agent due to cancel request!");
-+                raise(SIGUSR1);
++                Log_Info("cancel requested while waiting for user consent");
++                CleanConsentRequestJsonFile();
++                workflow_free_string(installedCriteria_workflow);
++                return Cancel(workflowData);
 +            }
 +
 +            if (true == UserConsentAgreed(version))

--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update_1.4.0.bb
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update_1.4.0.bb
@@ -14,7 +14,7 @@ def aduc_version(d, idx):
     return parts[idx]
 
 SRC_URI = " \
-  git://github.com/azure/iot-hub-device-update.git;protocol=https;tag=1.2.6;nobranch=1 \
+  git://github.com/azure/iot-hub-device-update.git;protocol=https;tag=1.4.0;nobranch=1 \
   file://deviceupdate-agent.service \
   file://deviceupdate-agent.timer \
   file://du-config.json \
@@ -22,7 +22,7 @@ SRC_URI = " \
   file://iot-hub-device-update.tmpfilesd \
   file://iot-identity-service-keyd.template.toml \
   file://iot-identity-service-identityd.template.toml \
-  file://omnect_1.2.6.patch \
+  file://omnect_1.4.0.patch \
   file://adu-bootloader-env \
 "
 SRC_URI:append:omnect_uboot = " file://swupdate_handler_v2_u-boot.sh"
@@ -118,9 +118,6 @@ do_install:append() {
   install -m 0660 -o adu -g adu ${S}/src/extensions/step_handlers/swupdate_consent_handler/files/request_consent.json ${D}${sysconfdir}/omnect/consent/
   install -d ${D}${sysconfdir}/omnect/consent/swupdate
   install -m 0660 -o adu -g adu ${S}/src/extensions/step_handlers/swupdate_consent_handler/files/user_consent.json ${D}${sysconfdir}/omnect/consent/swupdate/
-
-  # delete adu-swupdate.sh
-  rm ${D}${bindir}/adu-swupdate.sh
 
   install -m 0440 -D ${WORKDIR}/adu-bootloader-env ${D}${sysconfdir}/sudoers.d/adu-bootloader-env
 }


### PR DESCRIPTION
## Summary
- Bump `iot-hub-device-update` recipe and the `omnect_*.patch` from 1.2.6 to 1.4.0.
- Drop the `adu-swupdate.sh` removal step in `do_install`; upstream deleted the script because the `microsoft/swupdate:1` handler is deprecated.
- Carry omnect fixes for cancel and cancel-to-replace of consent-gated updates (issue #511), replacing the old SIGUSR1 agent-restart workaround:
  - consent step returns `Failure_Cancelled` on cancel instead of restarting the agent;
  - `workflow_transfer_data` rebuilds step children on replacement so the new deployment uses its own `installedCriteria` instead of the replaced one's.