### PR TITLE
feat: introduced more image wide hardening (mainly RELRO)

### DIFF
--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -100,5 +100,8 @@ env:
 
 local_conf_header:
   meta-omnect_distro_omnect-os: |
+    # take advantage of openembedded-core's hardening settings
+    require conf/distro/include/security_flags.inc
+    
     # For more options have a look into "poky/meta-poky/conf/local.conf.sample" resp.
     # "openebedded-core/meta/conf/local.conf.sample".

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -102,6 +102,6 @@ local_conf_header:
   meta-omnect_distro_omnect-os: |
     # take advantage of openembedded-core's hardening settings
     require conf/distro/include/security_flags.inc
-    
+
     # For more options have a look into "poky/meta-poky/conf/local.conf.sample" resp.
     # "openebedded-core/meta/conf/local.conf.sample".

--- a/kas/distro/omnect-os.yaml
+++ b/kas/distro/omnect-os.yaml
@@ -101,7 +101,7 @@ env:
 local_conf_header:
   meta-omnect_distro_omnect-os: |
     # take advantage of openembedded-core's hardening settings
-    require conf/distro/include/security_flags.inc
+    require ${LAYERDIR_core}/conf/distro/include/security_flags.inc
 
     # For more options have a look into "poky/meta-poky/conf/local.conf.sample" resp.
     # "openebedded-core/meta/conf/local.conf.sample".


### PR DESCRIPTION
Hardening aspect RELRO protects attacks that modify addresses of dynamically linked functions which are stored in the global offset table (GOT) by making these tables read-only after relocation.

This commit introduces image wide RELRO settings (where applicable) with two exceptions:

- go compiler for 32 bit ARM architectures doesn't support position independent code (PCIE) generation and hence no complete RELRO support exists; this affects applications runc as well as containerd-shim-runc-v2
- for other architectures (x86-64 and arm64) runc has ful RELRO support, but containerd-shim-runc-v2 is by design deliberately excepted from that via its recipe in meta-virtualization