### PR TITLE
fix(kernel): narrow do_sign/do_deploy DISTRO_FEATURES vardep to secureboot

### DIFF
--- a/dynamic-layers/phytec/recipes-kernel/linux/linux-phytec-imx_%.bbappend
+++ b/dynamic-layers/phytec/recipes-kernel/linux/linux-phytec-imx_%.bbappend
@@ -1,3 +1,24 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/linux:"
 
 SRC_URI += "file://0001-feat-linux-imx-added-ramoops-for-tauril2.patch"
+
+# Both linux-common-secureboot.inc's do_sign() ("secureboot" in
+# d.getVar('DISTRO_FEATURES')) and linux-phytec-fitimage.inc's
+# do_deploy:append() ("echo ${DISTRO_FEATURES} | grep -wq secureboot")
+# read the *raw* DISTRO_FEATURES string directly. BitBake's vardep
+# scanner therefore ties do_sign/do_deploy's taskhash to the ENTIRE
+# feature list, not just secureboot membership. Because do_compile,
+# do_configure, do_kernel_metadata etc. have no sstate object of their
+# own, any unrelated DISTRO_FEATURES churn (e.g. wifi/bluetooth flags
+# driven by device_caps.json, see commit e1ad988) forces the whole
+# kernel/module compile lineage to re-run for real, while
+# do_package_write_ipk's own (unrelated) signature stays cache-hit --
+# producing a kernel/module version mismatch (observed 2026-07-10,
+# build 107 of omnect-os-build/tauril2 gateway-devel). Narrow the
+# tracked dependency to just the boolean outcome these tasks actually
+# care about.
+SECUREBOOT_ENABLED := "${@bb.utils.contains('DISTRO_FEATURES', 'secureboot', '1', '0', d)}"
+do_sign[vardeps] += "SECUREBOOT_ENABLED"
+do_sign[vardepsexclude] += "DISTRO_FEATURES"
+do_deploy[vardeps] += "SECUREBOOT_ENABLED"
+do_deploy[vardepsexclude] += "DISTRO_FEATURES"


### PR DESCRIPTION
## Problem

`do_sign` (`recipes-kernel/linux/linux-common-secureboot.inc`) and `do_deploy` (`linux-phytec-fitimage.inc`, from meta-phytec) each read the **raw** `DISTRO_FEATURES` string directly to check for `secureboot` membership:

```python
python do_sign() {
    if "secureboot" in d.getVar('DISTRO_FEATURES'):
```
```sh
do_deploy:append() {
    if echo ${DISTRO_FEATURES} | grep -wq "secureboot"; then
```

BitBake's automatic vardep scanner ties both tasks' taskhash to the *entire* feature list, not just the `secureboot` flag. Because `do_compile`/`do_configure`/`do_kernel_metadata`/`do_compile_kernelmodules` have no sstate object of their own (only `do_populate_lic`, `do_package*`, `do_populate_sysroot`, `do_packagedata`, `do_deploy` participate in sstate for this recipe), **any** unrelated `DISTRO_FEATURES` change forces the *entire* kernel compile lineage to re-run for real on the next build — while `do_package_write_ipk`'s own signature is untouched and gets served from an older cached sstate object.

## Observed incident

In `omnect-os-build/tauril2,gateway-devel` build 107 (2026-07-10), the `device_caps.json`-driven `DISTRO_FEATURES` rework (#665 / e1ad988) changed `DISTRO_FEATURES`'s value for unrelated wifi/bluetooth reasons. This invalidated `do_sign`/`do_deploy`'s taskhash, forcing a fresh kernel rebuild (`do_kernel_metadata` → ... → `do_compile_kernelmodules` → `do_deploy`, all real executions, confirmed in the Concourse build log). Meanwhile `do_package_write_ipk` hit the shared sstate cache with an object from build 104. The result: the deployed kernel Image and the packaged kernel modules originated from two different kernel builds and failed to load on the device (module version magic mismatch, confirmed via `uname -r` vs. the modules directory name differing in their kernel-yocto merge-tree hash).

## Fix

Add a derived `SECUREBOOT_ENABLED` variable and exclude the raw `DISTRO_FEATURES` var from `do_sign`/`do_deploy`'s tracked vardeps, so their taskhash only changes when `secureboot` membership itself actually toggles — not on every unrelated `DISTRO_FEATURES` churn.

## Scope / limitations

This closes the specific trigger seen in this incident. It does **not** fix the general architectural gap that `do_package_write_ipk`/`do_populate_sysroot` have no dependency on whether `do_compile_kernelmodules` was actually re-executed vs. served from sstate — a follow-up hardening this dependency directly is being considered separately.