### PR TITLE
feat(image): guard against kernel/modules version mismatch

### DIFF
--- a/classes/omnect-verify-kernel-modules.bbclass
+++ b/classes/omnect-verify-kernel-modules.bbclass
@@ -1,0 +1,85 @@
+# Guards against the kernel Image and the shipped kernel-modules package
+# being built from different kernel source states.
+#
+# Background: BitBake's per-task sstate/setscene mechanism can restore
+# do_package_write_ipk/do_populate_sysroot for the kernel recipe from an
+# older cached object while do_compile/do_sign/do_deploy execute fresh in
+# the SAME build - each decision is made independently, based only on
+# whether a given task's own declared taskhash matches something already
+# cached. For linux-yocto style kernel recipes this is compounded by the
+# kernel-yocto SCC/KMETA merge tree embedding a non-reproducible
+# git-describe hash into LOCALVERSION/vermagic that BitBake's signatures
+# never track - so even a taskhash match doesn't guarantee identical
+# actual output.
+#
+# When this happens, the produced image boots a kernel whose modules
+# directory (embedded LOCALVERSION) doesn't match the kernel's own
+# reported version, and modules silently fail to load
+# ("modprobe: ERROR: ... invalid module format" / similar). See incident
+# 2026-07-10, build 107 of omnect-os-build/tauril2,gateway-devel, and
+# meta-omnect PR #670 for the part of the root cause that could be fixed
+# by narrowing a spurious do_sign/do_deploy signature dependency. This
+# class catches the *general* class of mismatch (any cause) at image
+# build time instead of letting it reach a device silently.
+#
+# Note: relies on the "Linux version ..." banner string being present as
+# plain ASCII inside the deployed kernel image blob (true for the
+# uncompressed arm64 "Image" format used by our machines; would need
+# adjustment - e.g. decompressing first - for machines using a
+# compressed KERNEL_IMAGETYPE such as zImage/uImage with gzip/lz4).
+
+python omnect_verify_kernel_module_consistency() {
+    import glob
+    import re
+
+    modules_dirs = glob.glob(d.expand("${IMAGE_ROOTFS}/lib/modules/*"))
+    if len(modules_dirs) != 1:
+        bb.warn("omnect-verify-kernel-modules: expected exactly one "
+                "${IMAGE_ROOTFS}/lib/modules/<version> directory, found "
+                "%d - skipping consistency check" % len(modules_dirs))
+        return
+    modules_version = os.path.basename(modules_dirs[0].rstrip("/"))
+
+    deploydir = d.getVar("DEPLOY_DIR_IMAGE")
+    candidates = sorted(
+        glob.glob(os.path.join(deploydir, "fitImage-*"))
+        + glob.glob(os.path.join(deploydir, "Image-*"))
+        + glob.glob(os.path.join(deploydir, "Image")),
+        key=os.path.getmtime,
+        reverse=True,
+    )
+    candidates = [c for c in candidates if os.path.isfile(c) and not os.path.islink(c)]
+    if not candidates:
+        bb.warn("omnect-verify-kernel-modules: no deployed kernel/fitImage "
+                "found under %s - skipping consistency check" % deploydir)
+        return
+
+    kernel_version = None
+    with open(candidates[0], "rb") as f:
+        data = f.read()
+    m = re.search(rb"Linux version (\S+)", data)
+    if m:
+        kernel_version = m.group(1).decode()
+
+    if kernel_version is None:
+        bb.warn("omnect-verify-kernel-modules: could not find a 'Linux "
+                "version' banner in %s - skipping consistency check "
+                "(likely a compressed KERNEL_IMAGETYPE not yet supported "
+                "by this check)" % candidates[0])
+        return
+
+    if kernel_version != modules_version:
+        bb.fatal(
+            "Kernel/modules version mismatch detected!\n"
+            "  deployed kernel (%s) reports: %s\n"
+            "  /lib/modules directory:       %s\n"
+            "The kernel Image and the packaged kernel modules were built "
+            "from different kernel source states (e.g. a stale sstate "
+            "cache hit for do_package_write_ipk/do_populate_sysroot while "
+            "the kernel itself was freshly rebuilt in the same build). "
+            "Refusing to produce an image whose modules would fail to "
+            "load at runtime." % (os.path.basename(candidates[0]),
+                                  kernel_version, modules_version))
+}
+
+IMAGE_POSTPROCESS_COMMAND:append = " omnect_verify_kernel_module_consistency;"

--- a/recipes-omnect/images/omnect-os-image.bb
+++ b/recipes-omnect/images/omnect-os-image.bb
@@ -200,6 +200,7 @@ python () {
 }
 
 inherit omnect_user
+inherit omnect-verify-kernel-modules
 
 # positive test for packages, i.e. check if installed
 check_installed_packages() {


### PR DESCRIPTION
## Problem

BitBake's per-task sstate/setscene mechanism decides cache reuse independently, per task, based only on whether a task's own declared taskhash matches an already-cached object. For linux-yocto style kernel recipes this means `do_package_write_ipk`/`do_populate_sysroot` can be sstate-restored from an *older* cached object while `do_compile`/`do_sign`/`do_deploy` execute fresh in the *same* build — each decision is individually 'correct' per BitBake's own bookkeeping.

This is compounded by the kernel-yocto SCC/KMETA merge tree embedding a non-reproducible `git describe` hash into `LOCALVERSION`/vermagic at build time, which BitBake's signatures never track. The result: a kernel Image and its shipped kernel-modules package can silently originate from two different kernel builds, producing an image whose modules fail to load at runtime (module version magic mismatch) — with no error anywhere in the build.

Observed directly in `omnect-os-build/tauril2,gateway-devel` build 107 (2026-07-10): confirmed via the Concourse build log that `do_package_write_ipk` was a setscene cache-restore from build 104, while `do_kernel_metadata`/`do_compile`/`do_sign`/`do_compile_kernelmodules`/`do_deploy` all executed fresh — and via device evidence (`uname -r` vs. the `/lib/modules` directory name showing different non-reproducible hash suffixes).

See #670 for the part of this specific incident's root cause that's fixable at the BitBake-signature level (a spurious `DISTRO_FEATURES` vardep on `do_sign`/`do_deploy`).

## Fix

This PR does **not** attempt to fix the caching behavior itself — that isn't reliably possible within BitBake's pre-execution signature model when the actual divergence stems from unTracked non-determinism in an upstream task's real output. Instead, it adds an `IMAGE_POSTPROCESS_COMMAND` check (`classes/omnect-verify-kernel-modules.bbclass`, inherited by `omnect-os-image.bb`) that:

1. Extracts the kernel version banner string (`Linux version ...`) from the deployed kernel/fitImage blob in `DEPLOY_DIR_IMAGE`.
2. Compares it against the `/lib/modules/<version>` directory name actually present in the built rootfs.
3. Fails the build (`bb.fatal`) if they don't match.

This is independent of and complements #670: it catches this class of mismatch regardless of cause, turning a silent runtime failure into a loud, immediate CI build failure — so an inconsistent image like build 107's never reaches a test device or the field again.

## Limitations / follow-ups

- Works for the uncompressed arm64 `Image` format used by our current machines (verified against `phygate-tauri-l-imx8mm-2`'s `KERNEL_IMAGETYPE = "Image"`). A compressed `KERNEL_IMAGETYPE` (zImage/uImage with gzip/lz4) would need the check extended to decompress first — it currently warns and skips rather than false-failing in that case.
- Does not identify *which* task was the stale one, only that a mismatch exists — for full incident triage the sstate siginfo comparison approach used in the original investigation is still the recommended method.
- Genuinely orthogonal to #670: can be merged independently, before, after, or without it.