### PR TITLE
feat(omnect-device-service): update to 0.45.0

### DIFF
--- a/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
+++ b/recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/omnect_1.4.0.patch
@@ -497,6 +497,103 @@ index 524747b7..d8156d0c 100644
                      workflow_transfer_data(
                          currentWorkflowData->WorkflowHandle /* wfTarget */, nextWorkflow /* wfSource */);
  
+diff --git a/src/agent/api/src/apisvc.c b/src/agent/api/src/apisvc.c
+index fc73768a..2a46ae38 100644
+--- a/src/agent/api/src/apisvc.c
++++ b/src/agent/api/src/apisvc.c
+@@ -90,7 +90,15 @@ bool uninit_api_svc()
+     void* threadRet = NULL;
+     FifoThreadRetVal* retVal = NULL;
+ 
+-    atomic_store(&g_api_svc_thread_running, false);
++    // The flag is set only after the thread was created, so a false value means
++    // g_api_svc_thread still holds the zero-initialized handle. Joining that
++    // dereferences a NULL thread descriptor.
++    if (!atomic_exchange(&g_api_svc_thread_running, false))
++    {
++        Log_Info("api service thread was not started, nothing to uninit");
++        return false;
++    }
++
+     int res = pthread_join(g_api_svc_thread, (void**)&threadRet);
+     if (res != 0)
+     {
+diff --git a/src/agent/api/tests/apisvc_unit_tests.cpp b/src/agent/api/tests/apisvc_unit_tests.cpp
+index f89578fc..868756ac 100644
+--- a/src/agent/api/tests/apisvc_unit_tests.cpp
++++ b/src/agent/api/tests/apisvc_unit_tests.cpp
+@@ -16,12 +16,15 @@
+ #include "aduc/viewstatemgr.h"
+ 
+ #include <arpa/inet.h>
++#include <atomic>
+ #include <catch2/catch_all.hpp>
+ #include <chrono>
++#include <dlfcn.h>
+ #include <errno.h>
+ #include <fcntl.h>
+ #include <filesystem>
+ #include <poll.h>
++#include <pthread.h>
+ #include <string.h>
+ #include <sys/stat.h>
+ #include <sys/types.h>
+@@ -84,6 +87,24 @@ using Catch::Matchers::Equals;
+ 
+ ViewStateManager g_vsm = { 0 };
+ 
++// Counts joins attempted on the zero-initialized thread handle. Joins of real
++// threads are forwarded to libc, so the other sections behave as before.
++static std::atomic<int> g_joinsOnZeroHandle{ 0 };
++
++extern "C" int pthread_join(pthread_t thread, void** retval)
++{
++    using JoinFn = int (*)(pthread_t, void**);
++    static auto realJoin = reinterpret_cast<JoinFn>(dlsym(RTLD_NEXT, "pthread_join"));
++
++    if (thread == static_cast<pthread_t>(0))
++    {
++        ++g_joinsOnZeroHandle;
++        return ESRCH;
++    }
++
++    return realJoin(thread, retval);
++}
++
+ TEST_CASE("apisvc crossproc tests")
+ {
+     // Ensure test data directory exists
+@@ -155,6 +176,30 @@ TEST_CASE("apisvc crossproc tests")
+         CHECK(uninit_api_svc());
+     }
+ 
++    SECTION("uninit without init")
++    {
++        // Joining the zero-initialized handle dereferences a NULL thread
++        // descriptor, which crashes on aarch64 glibc (agent shutdown after a
++        // failed startup).
++        g_joinsOnZeroHandle = 0;
++
++        CHECK_FALSE(uninit_api_svc());
++        CHECK(g_joinsOnZeroHandle == 0);
++    }
++
++    SECTION("uninit twice")
++    {
++        const std::string reqFifoPath = TEST_DATA_DIR + "/test_req_fifo";
++
++        REQUIRE(init_api_svc(reqFifoPath.c_str()));
++        std::this_thread::sleep_for(std::chrono::milliseconds(100));
++        g_joinsOnZeroHandle = 0;
++
++        CHECK(uninit_api_svc());
++        CHECK_FALSE(uninit_api_svc());
++        CHECK(g_joinsOnZeroHandle == 0);
++    }
++
+     SECTION("GetAduServiceStatus via SDK API")
+     {
+         REQUIRE(viewstatemgr_svcstatus_set(&g_vsm, ADUC_ServiceStatus_Idle));
 diff --git a/src/agent/src/health_management.c b/src/agent/src/health_management.c
 index 38ad9ea5..b32dcc33 100644
 --- a/src/agent/src/health_management.c

--- a/recipes-omnect/omnect-device-service/omnect-device-service.inc
+++ b/recipes-omnect/omnect-device-service/omnect-device-service.inc
@@ -85,11 +85,11 @@ do_install:append() {
     #        folder
     install -m 0755 -D ${S}/healthcheck/healthchecklib.sh                   ${D}/${sbindir}/healthchecklib.sh
     install -m 0755 -D ${S}/healthcheck/omnect_health_check.sh              ${D}/${sbindir}/omnect_health_check.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health__coredumps.sh         ${D}/${sbindir}/omnect_health__coredumps.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health__services.sh          ${D}/${sbindir}/omnect_health__services.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health__system_running.sh    ${D}/${sbindir}/omnect_health__system_running.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health__crash_loop.sh        ${D}/${sbindir}/omnect_health__crash_loop.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health__timesync.sh          ${D}/${sbindir}/omnect_health__timesync.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health_coredumps.sh          ${D}/${sbindir}/omnect_health_coredumps.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health_services.sh           ${D}/${sbindir}/omnect_health_services.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health_system_running.sh     ${D}/${sbindir}/omnect_health_system_running.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health_crash_loop.sh         ${D}/${sbindir}/omnect_health_crash_loop.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health_timesync.sh           ${D}/${sbindir}/omnect_health_timesync.sh
     install -m 0755 -D ${S}/healthcheck/omnect_service_log.sh               ${D}/${sbindir}/omnect_service_log.sh
     # NOTE:
     #    the next script needs to be always there, regardless of whether
@@ -154,11 +154,11 @@ FILES:${PN} += "\
 FILES:${PN} += "\
 	${sbindir}/healthchecklib.sh \
 	${sbindir}/omnect_health_check.sh \
-	${sbindir}/omnect_health__coredumps.sh \
-	${sbindir}/omnect_health__services.sh \
-	${sbindir}/omnect_health__system_running.sh \
-	${sbindir}/omnect_health__crash_loop.sh \
-	${sbindir}/omnect_health__timesync.sh \
+	${sbindir}/omnect_health_coredumps.sh \
+	${sbindir}/omnect_health_services.sh \
+	${sbindir}/omnect_health_system_running.sh \
+	${sbindir}/omnect_health_crash_loop.sh \
+	${sbindir}/omnect_health_timesync.sh \
 	${sbindir}/omnect_service_log.sh \
 	${sbindir}/omnect_reboot_reason.sh \
 	${sysconfdir}/omnect/health_check/omnect_service_log_analysis.json \

--- a/recipes-omnect/omnect-device-service/omnect-device-service.inc
+++ b/recipes-omnect/omnect-device-service/omnect-device-service.inc
@@ -85,11 +85,11 @@ do_install:append() {
     #        folder
     install -m 0755 -D ${S}/healthcheck/healthchecklib.sh                   ${D}/${sbindir}/healthchecklib.sh
     install -m 0755 -D ${S}/healthcheck/omnect_health_check.sh              ${D}/${sbindir}/omnect_health_check.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health_coredumps.sh          ${D}/${sbindir}/omnect_health_coredumps.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health_services.sh           ${D}/${sbindir}/omnect_health_services.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health_system_running.sh     ${D}/${sbindir}/omnect_health_system_running.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health_crash_loop.sh         ${D}/${sbindir}/omnect_health_crash_loop.sh
-    install -m 0755 -D ${S}/healthcheck/omnect_health_timesync.sh           ${D}/${sbindir}/omnect_health_timesync.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health__coredumps.sh         ${D}/${sbindir}/omnect_health__coredumps.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health__services.sh          ${D}/${sbindir}/omnect_health__services.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health__system_running.sh    ${D}/${sbindir}/omnect_health__system_running.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health__crash_loop.sh        ${D}/${sbindir}/omnect_health__crash_loop.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health__timesync.sh          ${D}/${sbindir}/omnect_health__timesync.sh
     install -m 0755 -D ${S}/healthcheck/omnect_service_log.sh               ${D}/${sbindir}/omnect_service_log.sh
     # NOTE:
     #    the next script needs to be always there, regardless of whether
@@ -154,11 +154,11 @@ FILES:${PN} += "\
 FILES:${PN} += "\
 	${sbindir}/healthchecklib.sh \
 	${sbindir}/omnect_health_check.sh \
-	${sbindir}/omnect_health_coredumps.sh \
-	${sbindir}/omnect_health_services.sh \
-	${sbindir}/omnect_health_system_running.sh \
-	${sbindir}/omnect_health_crash_loop.sh \
-	${sbindir}/omnect_health_timesync.sh \
+	${sbindir}/omnect_health__coredumps.sh \
+	${sbindir}/omnect_health__services.sh \
+	${sbindir}/omnect_health__system_running.sh \
+	${sbindir}/omnect_health__crash_loop.sh \
+	${sbindir}/omnect_health__timesync.sh \
 	${sbindir}/omnect_service_log.sh \
 	${sbindir}/omnect_reboot_reason.sh \
 	${sysconfdir}/omnect/health_check/omnect_service_log_analysis.json \

--- a/recipes-omnect/omnect-device-service/omnect-device-service.inc
+++ b/recipes-omnect/omnect-device-service/omnect-device-service.inc
@@ -88,6 +88,7 @@ do_install:append() {
     install -m 0755 -D ${S}/healthcheck/omnect_health__coredumps.sh         ${D}/${sbindir}/omnect_health__coredumps.sh
     install -m 0755 -D ${S}/healthcheck/omnect_health__services.sh          ${D}/${sbindir}/omnect_health__services.sh
     install -m 0755 -D ${S}/healthcheck/omnect_health__system_running.sh    ${D}/${sbindir}/omnect_health__system_running.sh
+    install -m 0755 -D ${S}/healthcheck/omnect_health__crash_loop.sh        ${D}/${sbindir}/omnect_health__crash_loop.sh
     install -m 0755 -D ${S}/healthcheck/omnect_health__timesync.sh          ${D}/${sbindir}/omnect_health__timesync.sh
     install -m 0755 -D ${S}/healthcheck/omnect_service_log.sh               ${D}/${sbindir}/omnect_service_log.sh
     # NOTE:
@@ -156,6 +157,7 @@ FILES:${PN} += "\
 	${sbindir}/omnect_health__coredumps.sh \
 	${sbindir}/omnect_health__services.sh \
 	${sbindir}/omnect_health__system_running.sh \
+	${sbindir}/omnect_health__crash_loop.sh \
 	${sbindir}/omnect_health__timesync.sh \
 	${sbindir}/omnect_service_log.sh \
 	${sbindir}/omnect_reboot_reason.sh \

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -7,8 +7,8 @@ inherit cargo
 
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
-SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "5e476fdba40e9b5bd0175de952e6e23c45c8cf5a"
+SRC_URI += "git://github.com/omnect/omnect-device-service.git;protocol=https;nobranch=1;branch=main"
+SRCREV = "a34303a576874c8b6716d90c403595a2f4892305"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "a086e99f055ff14ca624f239376c04647e39815c"
+SRCREV = "c6e07bd82a23aacb7bbc0be7c3d4753fbfc54305"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "8e267a4585b0485c46ac3338ea0eade80360ce8d"
+SRCREV = "a086e99f055ff14ca624f239376c04647e39815c"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "1248f3c847215289a3f25dad7af5f17e3a4fa0f3"
+SRCREV = "b9f18deed1f651a918231c6481cad65a59e09511"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "2367e7ac290a6c5c1f63331f9176da76c1abebbd"
+SRCREV = "fb6ec7cee353dea8ecb0975b0e2b79b9ff328672"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "fb6ec7cee353dea8ecb0975b0e2b79b9ff328672"
+SRCREV = "5e476fdba40e9b5bd0175de952e6e23c45c8cf5a"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "4ec4b2e0ca9cc05e150990231903f9051262b022"
+SRCREV = "2367e7ac290a6c5c1f63331f9176da76c1abebbd"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "b9f18deed1f651a918231c6481cad65a59e09511"
+SRCREV = "523e7fba70f93f1736e8c00f21c1000e939d7b02"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "523e7fba70f93f1736e8c00f21c1000e939d7b02"
+SRCREV = "8e267a4585b0485c46ac3338ea0eade80360ce8d"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -8,7 +8,7 @@ inherit cargo
 # how to get omnect-device-service could be as easy as but default to a git checkout:
 # SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
 SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
-SRCREV = "c6e07bd82a23aacb7bbc0be7c3d4753fbfc54305"
+SRCREV = "4ec4b2e0ca9cc05e150990231903f9051262b022"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.0.bb
@@ -6,9 +6,9 @@ inherit cargo
 # DEFAULT_PREFERENCE = "-1"
 
 # how to get omnect-device-service could be as easy as but default to a git checkout:
-# SRC_URI += "crate://crates.io/omnect-device-service/0.44.0"
-SRC_URI += "git://github.com/omnect/omnect-device-service.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "4d6be836f1b47d55e7479eae28d251b6a64348f2"
+# SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
+SRC_URI += "git://github.com/JanZachmann/omnect-device-service.git;protocol=https;nobranch=1;branch=jz-2026-07-28-wait-for-system-healthy"
+SRCREV = "1248f3c847215289a3f25dad7af5f17e3a4fa0f3"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 
@@ -47,6 +47,7 @@ SRC_URI += " \
     crate://crates.io/base64/0.21.7 \
     crate://crates.io/base64/0.22.1 \
     crate://crates.io/bindgen/0.71.1 \
+    crate://crates.io/bindgen/0.72.1 \
     crate://crates.io/bitflags/1.3.2 \
     crate://crates.io/bitflags/2.13.0 \
     crate://crates.io/block-buffer/0.10.4 \
@@ -512,15 +513,16 @@ SRCREV_FORMAT .= "_aziot-keyd-config"
 SRCREV_aziot-keyd-config = "1.5.5"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/aziot-keyd-config"
 SRCREV_FORMAT .= "_azure-iot-sdk"
-SRCREV_azure-iot-sdk = "0.14.1"
+SRCREV_azure-iot-sdk = "0.14.2"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/azure-iot-sdk"
 SRCREV_FORMAT .= "_azure-iot-sdk-sys"
-SRCREV_azure-iot-sdk-sys = "0.6.3"
+SRCREV_azure-iot-sdk-sys = "0.6.4"
 EXTRA_OECARGO_PATHS += "${WORKDIR}/azure-iot-sdk-sys"
 SRC_URI[base64-0.13.1.sha256sum] = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 SRC_URI[base64-0.21.7.sha256sum] = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
 SRC_URI[base64-0.22.1.sha256sum] = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 SRC_URI[bindgen-0.71.1.sha256sum] = "5f58bf3d7db68cfbac37cfc485a8d711e87e064c3d0fe0435b92f7a407f9d6b3"
+SRC_URI[bindgen-0.72.1.sha256sum] = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 SRC_URI[bitflags-1.3.2.sha256sum] = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 SRC_URI[bitflags-2.13.0.sha256sum] = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 SRC_URI[block-buffer-0.10.4.sha256sum] = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"


### PR DESCRIPTION
## Summary
- new ods recipe 0.45.0 (generated with cargo-bitbake)
- ods 0.45.0 replaces the broken update-validation system-state wait with a polling health check that fails fast on degraded state or crash-looping services (omnect/omnect-device-service#206)
- install the new omnect_health_crash_loop.sh health check script
- update the iot-hub-device-update patch to fix another crash revealed by the CI tests for this change