### PR TITLE
fix(aziot-identityd): let precondition service reach failed state

### DIFF
--- a/recipes-azure-iot/azure-identityd/aziot-identityd.inc
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd.inc
@@ -17,6 +17,7 @@ SRC_URI += " \
 # workspace
 SRC_URI += " \
     file://aziot-identityd-precondition.service \
+    file://aziot-identityd-precondition.timer \
     file://iot-identity-service.conf \
     file://iot-identity-service-certd.template.toml \
 "
@@ -189,6 +190,7 @@ do_install() {
     else
         sed -i "s/@@AZIOTCLI@@/aziotctl/" ${D}${systemd_system_unitdir}/aziot-identityd-precondition.service
     fi
+    install -m 0644 ${WORKDIR}/aziot-identityd-precondition.timer ${D}${systemd_system_unitdir}/aziot-identityd-precondition.timer
 }
 
 pkg_postinst:${PN}() {
@@ -209,6 +211,7 @@ SYSTEMD_SERVICE:${PN} = " \
     aziot-identityd.service \
     aziot-identityd.socket \
     aziot-identityd-precondition.service \
+    aziot-identityd-precondition.timer \
     aziot-keyd.service \
     aziot-keyd.socket \
 "

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.service
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.service
@@ -17,10 +17,11 @@ ConditionPathExists=|/run/omnect-device-service/omnect_bootloader_updated
 ConditionFileNotEmpty=|!/etc/aziot/identityd/config.d/00-super.toml
 
 # with RestartSec=5 the default limit (5 starts per 10s) is never reached, so
-# the unit would loop in auto-restart forever instead of failing; keep the
-# window short, the aziot stack is ordered after this unit
+# the unit would loop in auto-restart forever instead of failing; the window
+# has to hold the whole burst, i.e. StartLimitBurst * (RestartSec + runtime of
+# one 'config apply')
 StartLimitBurst=5
-StartLimitIntervalSec=60
+StartLimitIntervalSec=120
 
 [Service]
 Type=oneshot

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.service
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.service
@@ -15,6 +15,8 @@ ConditionPathExists=|/run/omnect-device-service/omnect_validate_update_failed
 ConditionPathExists=|/run/omnect-device-service/omnect_bootloader_updated
 
 ConditionFileNotEmpty=|!/etc/aziot/identityd/config.d/00-super.toml
+StartLimitBurst=5
+StartLimitIntervalSec=60
 
 [Service]
 Type=oneshot

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.service
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.service
@@ -15,6 +15,10 @@ ConditionPathExists=|/run/omnect-device-service/omnect_validate_update_failed
 ConditionPathExists=|/run/omnect-device-service/omnect_bootloader_updated
 
 ConditionFileNotEmpty=|!/etc/aziot/identityd/config.d/00-super.toml
+
+# with RestartSec=5 the default limit (5 starts per 10s) is never reached, so
+# the unit would loop in auto-restart forever instead of failing; keep the
+# window short, the aziot stack is ordered after this unit
 StartLimitBurst=5
 StartLimitIntervalSec=60
 

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.timer
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.timer
@@ -1,0 +1,8 @@
+[Unit]
+Description=Retry Azure IoT Identity Service Precondition
+
+[Timer]
+OnUnitInactiveSec=10min
+
+[Install]
+WantedBy=timers.target

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.timer
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/aziot-identityd-precondition.timer
@@ -2,6 +2,7 @@
 Description=Retry Azure IoT Identity Service Precondition
 
 [Timer]
+# must exceed the unit's start-limit window, else the retry is rejected as well
 OnUnitInactiveSec=10min
 
 [Install]


### PR DESCRIPTION
## Summary
- add StartLimitBurst=5 / StartLimitIntervalSec=120 to aziot-identityd-precondition.service so a persistent failure reaches 'failed' (~30 s) instead of looping in 'activating' forever
- add aziot-identityd-precondition.timer (OnUnitInactiveSec=10min) so transient failures still recover: the retry runs after the rate-limit window has passed

## Reason
With Restart=on-failure/RestartSec=5 and the default start limit (5 in 10 s) the rate limit could never be reached: a persistently failing precondition looped in 'activating' forever and never showed up in 'systemctl is-system-running'. 