### PR TITLE
fix(bootloader-env): block all fw_setenv options, not only -s/--script

### DIFF
--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
@@ -11,7 +11,7 @@ function help() {
 function get() {
     [[ ${argsc} -ne 2 ]] && help && exit 1
     local key=${1}
-    local value=$(fw_printenv ${key})
+    local value=$(fw_printenv -- ${key})
     value=${value#${key}=}
     [[ -z "${value}" ]] && echo && exit 2
     echo ${value}
@@ -27,19 +27,17 @@ function set () {
     local key=${1}
     local value=${@:2}
 
-    for word in $key $value; do
-        if [[ "$word" == "-s" || "$word" == "--script" || "$word" == -s=* || "$word" == --script=* ]]; then
-            echo "Script-file mode is not allowed (flag: $word)"; exit 66;
-        fi
-    done
-
-    fw_setenv "${key}" "${value}"
+    # '--' ends option parsing, so key and value are always treated as data.
+    # this blocks script mode and every other option, e.g. an attacker-chosen
+    # config file, which a flag blocklist would miss (getopt accepts attached
+    # values like -sFILE and abbreviations like --scr=FILE)
+    fw_setenv -- "${key}" "${value}"
 }
 
 function unset() {
     [[ ${argsc} -ne 2 ]] && help && exit 1
     local key=${1}
-    fw_setenv "${key}"
+    fw_setenv -- "${key}"
 }
 
 [[ ${#} -lt 1 ]] && help && exit 1

--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
@@ -11,10 +11,10 @@ function help() {
 function get() {
     [[ ${argsc} -ne 2 ]] && help && exit 1
     local key=${1}
-    local value=$(fw_printenv -- ${key})
-    value=${value#${key}=}
+    local value=$(fw_printenv -- "${key}")
+    value=${value#"${key}"=}
     [[ -z "${value}" ]] && echo && exit 2
-    echo ${value}
+    printf '%s\n' "${value}"
 }
 
 function list(){

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.1.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.1.bb
@@ -6,9 +6,9 @@ inherit cargo
 # DEFAULT_PREFERENCE = "-1"
 
 # how to get omnect-device-service could be as easy as but default to a git checkout:
-# SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
+# SRC_URI += "crate://crates.io/omnect-device-service/0.45.1"
 SRC_URI += "git://github.com/omnect/omnect-device-service.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "a34303a576874c8b6716d90c403595a2f4892305"
+SRCREV = "f5a2c5671d500e2187b651fb51afcc8d0b2d06a4"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 


### PR DESCRIPTION
## Summary
`bootloader_env.sh set` (u-boot variant) passes `--` to `fw_setenv` instead of comparing
key and value against a list of known flags. Same for `unset` and `get`, whose key reaches
`fw_setenv` / `fw_printenv` the same way.

Also updates omnect-device-service to 0.45.1, which carries the same fix for its own wrapper `sudo/fw_setenv_no_script.sh`. Recipe regenerated with cargo-bitbake; the crate set did not change.

## Reason
The blocklist covered `-s`, `--script`, `-s=*` and `--script=*`. `fw_setenv`
(libubootenv, `src/fw_printenv.c`) parses its arguments with `getopt_long` and the
optstring `Vc:f:s:nhm:`, which accepts attached values (`-sFILE`) and abbreviations
(`--scr=FILE`), so those forms passed the filter and reached `fw_setenv` as options.
GNU getopt also keeps scanning after the first positional argument, so the value
position is enough.

`recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/adu-bootloader-env`
pins the key but passes the value unfiltered for `omnect_extra_bootargs` and
`omnect_validate_extra_bootargs`, so the `adu` user could write files as root — via a
script file (`-s`) or an attacker-chosen config (`-c`), the latter not covered by a
`-s`/`--script` blocklist at all.

This is the same defect that was fixed in omnect-device-service's `fw_setenv_no_script.sh`
(omnect/omnect-device-service#208); this script is the second copy of it. Both copies ship in the same image, so the ods pin belongs here — otherwise the image keeps the unfixed wrapper.
