### PR TITLE
fix(bootloader-env): block all fw_setenv options, not only -s/--script

### DIFF
--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
@@ -1,8 +1,6 @@
 #!/bin/bash -e
 set -o pipefail
 grubenv="/boot/EFI/BOOT/grubenv"
-commands=("get" "list" "set" "unset")
-argsc=${#}
 
 function help() {
     echo "usage:"
@@ -10,37 +8,36 @@ function help() {
     echo "    command: {get,list,set,unset}"
 }
 
-function get() {
-    [[ ${argsc} -ne 2 ]] && help && exit 1
-    local key=${1}
-    local value=$(grub-editenv ${grubenv} list | grep ^${key}=)
-    value=${value#${key}=}
+function cmd_get() {
+    [[ ${#} -ne 1 ]] && help && exit 1
+    local key="${1}"
+    local value=$(grub-editenv "${grubenv}" list | grep "^${key}=")
+    value="${value#"${key}"=}"
     [[ -z "${value}" ]] && echo && exit 2
-    echo ${value}
+    echo "${value}"
 }
 
-function list(){
-    [[ ${argsc} -ne 1 ]] && help && exit 1
-    grub-editenv ${grubenv} list
+function cmd_list() {
+    [[ ${#} -ne 0 ]] && help && exit 1
+    grub-editenv "${grubenv}" list
 }
 
-function set () {
-    [[ ${argsc} -ne 3 ]] && help && exit 1
-    local key=${1}
-    local value=${@:2}
-    grub-editenv ${grubenv} set "${key}"="${value}"
+function cmd_set() {
+    [[ ${#} -ne 2 ]] && help && exit 1
+    local key="${1}"
+    local value="${2}"
+    grub-editenv "${grubenv}" set "${key}"="${value}"
     sync
 }
 
-function unset() {
-    [[ ${argsc} -ne 2 ]] && help && exit 1
-    local key=${1}
-    grub-editenv ${grubenv} unset "${key}"
+function cmd_unset() {
+    [[ ${#} -ne 1 ]] && help && exit 1
+    local key="${1}"
+    grub-editenv "${grubenv}" unset "${key}"
     sync
 }
 
 [[ ${#} -lt 1 ]] && help && exit 1
-[[ ! " ${commands[@]} " =~ " ${1} " ]] && help && exit 1
+declare -F "cmd_${1}" > /dev/null || { help; exit 1; }
 
-#exec
-${1} ${@:2}
+"cmd_${1}" "${@:2}"

--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_grub.sh
@@ -14,7 +14,7 @@ function cmd_get() {
     local value=$(grub-editenv "${grubenv}" list | grep "^${key}=")
     value="${value#"${key}"=}"
     [[ -z "${value}" ]] && echo && exit 2
-    echo "${value}"
+    printf '%s\n' "${value}"
 }
 
 function cmd_list() {

--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
@@ -12,7 +12,7 @@ function cmd_get() {
     local value=$(fw_printenv -- "${key}")
     value="${value#"${key}"=}"
     [[ -z "${value}" ]] && echo && exit 2
-    echo "${value}"
+    printf '%s\n' "${value}"
 }
 
 function cmd_list() {

--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
@@ -11,7 +11,7 @@ function help() {
 function get() {
     [[ ${argsc} -ne 2 ]] && help && exit 1
     local key=${1}
-    local value=$(fw_printenv ${key})
+    local value=$(fw_printenv -- ${key})
     value=${value#${key}=}
     [[ -z "${value}" ]] && echo && exit 2
     echo ${value}
@@ -27,19 +27,17 @@ function set () {
     local key=${1}
     local value=${@:2}
 
-    for word in $key $value; do
-        if [[ "$word" == "-s" || "$word" == "--script" || "$word" == -s=* || "$word" == --script=* ]]; then
-            echo "Script-file mode is not allowed (flag: $word)"; exit 66;
-        fi
-    done
-
-    fw_setenv "${key}" "${value}"
+    # '--' ends option parsing, so key and value are always treated as data.
+    # this blocks script mode and every other option, e.g. an attacker-chosen
+    # config file, which a flag blocklist would miss (getopt accepts attached
+    # values like -sFILE and abbreviations like --scr=FILE)
+    fw_setenv -- "${key}" "${value}"
 }
 
 function unset() {
     [[ ${argsc} -ne 2 ]] && help && exit 1
     local key=${1}
-    fw_setenv "${key}"
+    fw_setenv -- "${key}"
 }
 
 [[ ${#} -lt 1 ]] && help && exit 1

--- a/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
+++ b/recipes-omnect/bootloader_env/bootloader-env/bootloader_env_u-boot.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
-commands=("get" "list" "set" "unset")
-argsc=${#}
 
 function help() {
     echo "usage:"
@@ -8,24 +6,24 @@ function help() {
     echo "    command: {get,list,set,unset}"
 }
 
-function get() {
-    [[ ${argsc} -ne 2 ]] && help && exit 1
-    local key=${1}
-    local value=$(fw_printenv -- ${key})
-    value=${value#${key}=}
+function cmd_get() {
+    [[ ${#} -ne 1 ]] && help && exit 1
+    local key="${1}"
+    local value=$(fw_printenv -- "${key}")
+    value="${value#"${key}"=}"
     [[ -z "${value}" ]] && echo && exit 2
-    echo ${value}
+    echo "${value}"
 }
 
-function list(){
-    [[ ${argsc} -ne 1 ]] && help && exit 1
+function cmd_list() {
+    [[ ${#} -ne 0 ]] && help && exit 1
     fw_printenv
 }
 
-function set () {
-    [[ ${argsc} -ne 3 ]] && help && exit 1
-    local key=${1}
-    local value=${@:2}
+function cmd_set() {
+    [[ ${#} -ne 2 ]] && help && exit 1
+    local key="${1}"
+    local value="${2}"
 
     # '--' ends option parsing, so key and value are always treated as data.
     # this blocks script mode and every other option, e.g. an attacker-chosen
@@ -34,14 +32,13 @@ function set () {
     fw_setenv -- "${key}" "${value}"
 }
 
-function unset() {
-    [[ ${argsc} -ne 2 ]] && help && exit 1
-    local key=${1}
+function cmd_unset() {
+    [[ ${#} -ne 1 ]] && help && exit 1
+    local key="${1}"
     fw_setenv -- "${key}"
 }
 
 [[ ${#} -lt 1 ]] && help && exit 1
-[[ ! " ${commands[@]} " =~ " ${1} " ]] && help && exit 1
+declare -F "cmd_${1}" > /dev/null || { help; exit 1; }
 
-#exec
-${1} ${@:2}
+"cmd_${1}" "${@:2}"

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.1.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.1.bb
@@ -6,9 +6,9 @@ inherit cargo
 # DEFAULT_PREFERENCE = "-1"
 
 # how to get omnect-device-service could be as easy as but default to a git checkout:
-# SRC_URI += "crate://crates.io/omnect-device-service/0.45.0"
+# SRC_URI += "crate://crates.io/omnect-device-service/0.45.1"
 SRC_URI += "git://github.com/omnect/omnect-device-service.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "a34303a576874c8b6716d90c403595a2f4892305"
+SRCREV = "f5a2c5671d500e2187b651fb51afcc8d0b2d06a4"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 


### PR DESCRIPTION
## Summary

Harden the u-boot bootloader_env.sh wrapper against `fw_setenv`/`fw_printenv` option injection, refactor the wrapper along the way, and pin omnect-device-service 0.45.1 which carries the same fix for its own wrapper `sudo/fw_setenv_no_script.sh`.

- Pass `--` to `fw_setenv`/`fw_printenv` so key and value are always treated as data. This blocks script mode and every other option, e.g. an attacker-chosen config file, which a flag blocklist would miss (getopt accepts attached values like `-sFILE` and abbreviations like `--scr=FILE`).
- Rename `set`/`unset`/`get`/`list` to `cmd_*` so nothing shadows the bash builtins.
- Each `cmd_*` takes its own quoted arguments and checks its own argc. Top-level dispatcher looks the function up via `declare -F` instead of an unquoted string match.
- `get` prints values with `printf '%s\n'` and strips the `key=` prefix with a quoted pattern, so values with a leading `-n`/`-e` and keys with glob metacharacters do not misbehave.
- Bump omnect-device-service to 0.45.1. Recipe regenerated with cargo-bitbake; crate set unchanged.

## Reason

The old blocklist covered `-s`, `--script`, `-s=*` and `--script=*`. `fw_setenv` parses arguments with `getopt_long` and the optstring `Vc:f:s:nhm:` (libubootenv, `src/fw_printenv.c`), which accepts attached values (`-sFILE`) and abbreviations (`--scr=FILE`), so those forms passed the filter and reached `fw_setenv` as options. GNU getopt also keeps scanning after the first positional argument, so the value position was enough to sneak in an option.

`recipes-azure-iot/iot-hub-device-update/iot-hub-device-update/adu-bootloader-env` pins the key but passes the value unfiltered for `omnect_extra_bootargs` and `omnect_validate_extra_bootargs`, so the `adu` user could write files as root — via a script file (`-s`) or an attacker-chosen config (`-c`), the latter not covered by a `-s`/`--script` blocklist at all.

The same defect existed in ods's own wrapper `sudo/fw_setenv_no_script.sh` (omnect/omnect-device-service#208). Both copies ship in the same image, so the ods pin belongs in this PR — otherwise the image would keep the unfixed wrapper.

Supersedes #678.
