### PR TITLE
chore(omnect-device-service): update to 0.45.2

### DIFF
--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.2.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.2.bb
@@ -12,7 +12,6 @@ SRCREV = "87758f7e2be5b74cd6ad7e952501f3ade00cec1a"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
 
-
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched
 SRC_URI += " \

--- a/recipes-omnect/omnect-device-service/omnect-device-service_0.45.2.bb
+++ b/recipes-omnect/omnect-device-service/omnect-device-service_0.45.2.bb
@@ -6,11 +6,12 @@ inherit cargo
 # DEFAULT_PREFERENCE = "-1"
 
 # how to get omnect-device-service could be as easy as but default to a git checkout:
-# SRC_URI += "crate://crates.io/omnect-device-service/0.45.1"
+# SRC_URI += "crate://crates.io/omnect-device-service/0.45.2"
 SRC_URI += "git://github.com/omnect/omnect-device-service.git;protocol=https;nobranch=1;branch=main"
-SRCREV = "f5a2c5671d500e2187b651fb51afcc8d0b2d06a4"
+SRCREV = "87758f7e2be5b74cd6ad7e952501f3ade00cec1a"
 S = "${WORKDIR}/git"
 CARGO_SRC_DIR = ""
+
 
 # please note if you have entries that do not begin with crate://
 # you must change them to how that package can be fetched


### PR DESCRIPTION
## Summary

Bumps the `omnect-device-service` recipe from 0.45.1 to 0.45.2.

## Reason

ods 0.45.2 makes the update validation timeout name the stage that was still pending, so the `swupdate-validation-failed` reboot reason says which step hung instead of tokio's generic "deadline has elapsed".
