### PR TITLE
fix(azure-identityd): wait for a working resolver before starting identityd

### DIFF
--- a/recipes-azure-iot/azure-identityd/aziot-identityd.inc
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd.inc
@@ -20,6 +20,7 @@ SRC_URI += " \
     file://aziot-identityd-precondition.timer \
     file://iot-identity-service.conf \
     file://iot-identity-service-certd.template.toml \
+    file://omnect_wait_dns_ready.sh \
 "
 
 CARGO_BUILD_FLAGS += "--offline"
@@ -35,7 +36,9 @@ DEPENDS = " \
 "
 
 RDEPENDS:${PN} = " \
+    bash \
     libtss2-tcti-device \
+    toml-cli \
 "
 
 do_compile() {
@@ -84,6 +87,7 @@ do_install() {
     # binaries
     install -d -m 0755  ${D}${bindir}
     install -m 0755     ${B}/target/${CARGO_TARGET_SUBDIR}/aziotctl ${D}${bindir}
+    install -m 0755     ${WORKDIR}/omnect_wait_dns_ready.sh ${D}${bindir}
 
     install -d -m 0750 -g aziot ${D}${libexecdir}/aziot-identity-service
     install -m 0750 -g aziot ${B}/target/${CARGO_TARGET_SUBDIR}/aziotd ${D}${libexecdir}/aziot-identity-service
@@ -142,7 +146,7 @@ do_install() {
         -e 's#^After=\(.*\)$#After=\1\nConditionPathExists=/etc/aziot/config.toml\nConditionPathExists=/etc/aziot/identityd/config.d/00-super.toml#' \
         -e 's#@libexecdir@#/usr/libexec#g' \
         -e '/Environment=\(.*\)$/d' \
-	-e 's#^ExecStart=\(.*\)$#ExecStartPre=+-bash -c "/usr/sbin/omnect_service_log.sh start aziot-identityd"\nExecStart=\1\nExecStopPost=+-/bin/sh -c "/usr/sbin/omnect_service_log.sh stop aziot-identityd \\"$$SERVICE_RESULT\\" \\"$$EXIT_CODE\\" \\"$$EXIT_STATUS\\""#' \
+	-e 's#^ExecStart=\(.*\)$#ExecStartPre=+-bash -c "/usr/sbin/omnect_service_log.sh start aziot-identityd"\nExecStartPre=+-/usr/bin/omnect_wait_dns_ready.sh\nExecStart=\1\nExecStopPost=+-/bin/sh -c "/usr/sbin/omnect_service_log.sh stop aziot-identityd \\"$$SERVICE_RESULT\\" \\"$$EXIT_CODE\\" \\"$$EXIT_STATUS\\""#' \
         -e 's/^Requires=\(.*\)$/Requires=\1 network-online.target/' \
         ${D}${systemd_system_unitdir}/aziot-identityd.service
     install -m 0644     ${S}/identity/aziot-identityd/aziot-identityd.socket.in ${D}${systemd_system_unitdir}/aziot-identityd.socket

--- a/recipes-azure-iot/azure-identityd/aziot-identityd.inc
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd.inc
@@ -147,7 +147,7 @@ do_install() {
         -e 's#^After=\(.*\)$#After=\1\nConditionPathExists=/etc/aziot/config.toml\nConditionPathExists=/etc/aziot/identityd/config.d/00-super.toml#' \
         -e 's#@libexecdir@#/usr/libexec#g' \
         -e '/Environment=\(.*\)$/d' \
-	-e 's#^ExecStart=\(.*\)$#ExecStartPre=+-bash -c "/usr/sbin/omnect_service_log.sh start aziot-identityd"\nExecStartPre=/usr/bin/omnect_wait_dns_ready.sh\nExecStart=\1\nExecStopPost=+-/bin/sh -c "/usr/sbin/omnect_service_log.sh stop aziot-identityd \\"$$SERVICE_RESULT\\" \\"$$EXIT_CODE\\" \\"$$EXIT_STATUS\\""#' \
+	-e 's#^ExecStart=\(.*\)$#ExecStartPre=+-bash -c "/usr/sbin/omnect_service_log.sh start aziot-identityd"\nExecStartPre=+/usr/bin/omnect_wait_dns_ready.sh\nExecStart=\1\nExecStopPost=+-/bin/sh -c "/usr/sbin/omnect_service_log.sh stop aziot-identityd \\"$$SERVICE_RESULT\\" \\"$$EXIT_CODE\\" \\"$$EXIT_STATUS\\""#' \
         -e 's/^Requires=\(.*\)$/Requires=\1 network-online.target/' \
         ${D}${systemd_system_unitdir}/aziot-identityd.service
     install -m 0644     ${S}/identity/aziot-identityd/aziot-identityd.socket.in ${D}${systemd_system_unitdir}/aziot-identityd.socket

--- a/recipes-azure-iot/azure-identityd/aziot-identityd.inc
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd.inc
@@ -147,7 +147,7 @@ do_install() {
         -e 's#^After=\(.*\)$#After=\1\nConditionPathExists=/etc/aziot/config.toml\nConditionPathExists=/etc/aziot/identityd/config.d/00-super.toml#' \
         -e 's#@libexecdir@#/usr/libexec#g' \
         -e '/Environment=\(.*\)$/d' \
-	-e 's#^ExecStart=\(.*\)$#ExecStartPre=+-bash -c "/usr/sbin/omnect_service_log.sh start aziot-identityd"\nExecStartPre=+-/usr/bin/omnect_wait_dns_ready.sh\nExecStart=\1\nExecStopPost=+-/bin/sh -c "/usr/sbin/omnect_service_log.sh stop aziot-identityd \\"$$SERVICE_RESULT\\" \\"$$EXIT_CODE\\" \\"$$EXIT_STATUS\\""#' \
+	-e 's#^ExecStart=\(.*\)$#ExecStartPre=+-bash -c "/usr/sbin/omnect_service_log.sh start aziot-identityd"\nExecStartPre=/usr/bin/omnect_wait_dns_ready.sh\nExecStart=\1\nExecStopPost=+-/bin/sh -c "/usr/sbin/omnect_service_log.sh stop aziot-identityd \\"$$SERVICE_RESULT\\" \\"$$EXIT_CODE\\" \\"$$EXIT_STATUS\\""#' \
         -e 's/^Requires=\(.*\)$/Requires=\1 network-online.target/' \
         ${D}${systemd_system_unitdir}/aziot-identityd.service
     install -m 0644     ${S}/identity/aziot-identityd/aziot-identityd.socket.in ${D}${systemd_system_unitdir}/aziot-identityd.socket

--- a/recipes-azure-iot/azure-identityd/aziot-identityd.inc
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd.inc
@@ -37,6 +37,7 @@ DEPENDS = " \
 
 RDEPENDS:${PN} = " \
     bash \
+    coreutils \
     libtss2-tcti-device \
     toml-cli \
 "

--- a/recipes-azure-iot/azure-identityd/aziot-identityd.inc
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd.inc
@@ -88,7 +88,7 @@ do_install() {
     # binaries
     install -d -m 0755  ${D}${bindir}
     install -m 0755     ${B}/target/${CARGO_TARGET_SUBDIR}/aziotctl ${D}${bindir}
-    install -m 0755     ${WORKDIR}/omnect_wait_dns_ready.sh ${D}${bindir}
+    install -m 0755     ${UNPACKDIR}/omnect_wait_dns_ready.sh ${D}${bindir}
 
     install -d -m 0750 -g aziot ${D}${libexecdir}/aziot-identity-service
     install -m 0750 -g aziot ${B}/target/${CARGO_TARGET_SUBDIR}/aziotd ${D}${libexecdir}/aziot-identity-service

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
@@ -8,7 +8,7 @@ TIMEOUT_SECONDS=30
 LOOKUP_TIMEOUT_SECONDS=5
 POLL_INTERVAL_SECONDS=1
 
-# est and dps are urls, the iothub a bare host; getent takes ipv6 unbracketed
+# est and dps are urls, the iothub a bare host
 function url_host()
 {
     local value="${1#*://}"
@@ -16,13 +16,7 @@ function url_host()
     value="${value%%/*}"
     value="${value##*@}"
 
-    case "${value}" in
-        \[*) value="${value#\[}"
-             echo "${value%%\]*}"
-             ;;
-        *)   echo "${value%%:*}"
-             ;;
-    esac
+    echo "${value%%:*}"
 }
 
 # which endpoint is needed first depends on the provisioning method, and they

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
@@ -19,7 +19,7 @@ function endpoint_host()
                provisioning.global_endpoint \
                provisioning.iothub_hostname; do
         value=$(toml get "${AZIOT_CONFIG}" "${key}" 2>/dev/null | tr -d '"')
-        [ -n "${value}" ] && [ "${value}" != "null" ] || continue
+        [ -n "${value}" ] || continue
         value="${value#*://}"
         value="${value%%/*}"
         echo "${value%%:*}"

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
@@ -21,7 +21,6 @@ function url_host()
 
 # which endpoint is needed first depends on the provisioning method, and they
 # are not the same domain, so every configured one is probed
-declare -A seen=()
 pending=()
 
 for key in cert_issuance.est.urls.default \
@@ -32,8 +31,7 @@ for key in cert_issuance.est.urls.default \
     [[ -n "${value}" ]] || continue
 
     host=$(url_host "${value}")
-    [[ -n "${host}" && -z "${seen[${host}]}" ]] || continue
-    seen["${host}"]=1
+    [[ -n "${host}" ]] || continue
     pending+=("${host}")
 done
 
@@ -54,6 +52,7 @@ while [[ ${#pending[@]} -gt 0 && "${SECONDS}" -lt "${deadline}" ]]; do
 
     pending=("${remaining[@]}")
     [[ ${#pending[@]} -gt 0 ]] || break
+    # a lookup that fails fast would spin this loop, so pace it
     sleep "${POLL_INTERVAL_SECONDS}"
 done
 

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+
+# aziot-identityd enrolls the device-id cert via EST and talks to DPS right at
+# start, and exits with an error when the resolver cannot answer yet.
+# network-online.target only tells us an interface is configured, so wait for
+# the name the daemon actually needs.
+
+AZIOT_CONFIG=/etc/aziot/config.toml
+TIMEOUT_SECONDS=30
+POLL_INTERVAL_SECONDS=1
+
+# host of the first configured endpoint; est and dps are configured as urls,
+# the iothub as a bare host
+function endpoint_host()
+{
+    local key value
+
+    for key in cert_issuance.est.urls.default \
+               provisioning.global_endpoint \
+               provisioning.iothub_hostname; do
+        value=$(toml get "${AZIOT_CONFIG}" "${key}" 2>/dev/null | tr -d '"')
+        [ -n "${value}" ] && [ "${value}" != "null" ] || continue
+        value="${value#*://}"
+        value="${value%%/*}"
+        echo "${value%%:*}"
+        return 0
+    done
+
+    return 1
+}
+
+host=$(endpoint_host) || exit 0
+
+# a lookup without a usable resolver blocks for the resolver timeout, so the
+# deadline is wall clock; counting attempts would multiply the wait by it
+deadline=$(( SECONDS + TIMEOUT_SECONDS ))
+while true; do
+    getent ahosts "${host}" > /dev/null && exit 0
+    [ "${SECONDS}" -lt "${deadline}" ] || break
+    sleep ${POLL_INTERVAL_SECONDS}
+done
+
+echo "${host} does not resolve after ${TIMEOUT_SECONDS}s, starting anyway" >&2
+exit 0

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
@@ -1,16 +1,13 @@
 #!/bin/bash
 
-# aziot-identityd enrolls the device-id cert via EST and talks to DPS right at
-# start, and exits with an error when the resolver cannot answer yet.
-# network-online.target only tells us an interface is configured, so wait for
-# the name the daemon actually needs.
+# network-online.target does not mean the resolver can answer, and identityd
+# exits with an error when it cannot resolve its endpoint at start.
 
 AZIOT_CONFIG=/etc/aziot/config.toml
 TIMEOUT_SECONDS=30
 POLL_INTERVAL_SECONDS=1
 
-# host of the first configured endpoint; est and dps are configured as urls,
-# the iothub as a bare host
+# est and dps are configured as urls, the iothub as a bare host
 function endpoint_host()
 {
     local key value
@@ -31,8 +28,8 @@ function endpoint_host()
 
 host=$(endpoint_host) || exit 0
 
-# a lookup without a usable resolver blocks for the resolver timeout, so the
-# deadline is wall clock; counting attempts would multiply the wait by it
+# a failing lookup blocks for the resolver timeout, so cap on wall clock and
+# not on attempts
 deadline=$(( SECONDS + TIMEOUT_SECONDS ))
 while true; do
     getent ahosts "${host}" > /dev/null && exit 0

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
@@ -8,8 +8,7 @@ TIMEOUT_SECONDS=30
 LOOKUP_TIMEOUT_SECONDS=5
 POLL_INTERVAL_SECONDS=1
 
-# est and dps are configured as urls, the iothub as a bare host. an ipv6 literal
-# is unwrapped because getent takes the bare address
+# est and dps are urls, the iothub a bare host; getent takes ipv6 unbracketed
 function url_host()
 {
     local value="${1#*://}"
@@ -26,8 +25,8 @@ function url_host()
     esac
 }
 
-# which endpoint identityd needs first depends on the provisioning method, and
-# they are not always the same domain, so every configured one is probed
+# which endpoint is needed first depends on the provisioning method, and they
+# are not the same domain, so every configured one is probed
 declare -A seen=()
 pending=()
 
@@ -47,9 +46,8 @@ done
 [[ ${#pending[@]} -gt 0 ]] || exit 0
 
 # a failing lookup blocks for the resolver timeout, so cap the single lookup and
-# the whole wait on wall clock and not on attempts. every host still pending
-# gets a try per pass, so one that never resolves cannot eat the deadline of the
-# others
+# the whole wait on wall clock. every host still pending gets a try per pass, so
+# one that never resolves cannot eat the deadline of the others
 deadline=$(( SECONDS + TIMEOUT_SECONDS ))
 
 while [[ ${#pending[@]} -gt 0 && "${SECONDS}" -lt "${deadline}" ]]; do

--- a/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
+++ b/recipes-azure-iot/azure-identityd/aziot-identityd/omnect_wait_dns_ready.sh
@@ -1,41 +1,71 @@
 #!/bin/bash
 
 # network-online.target does not mean the resolver can answer, and identityd
-# exits with an error when it cannot resolve its endpoint at start.
+# exits with an error when it cannot resolve an endpoint at start.
 
 AZIOT_CONFIG=/etc/aziot/config.toml
 TIMEOUT_SECONDS=30
+LOOKUP_TIMEOUT_SECONDS=5
 POLL_INTERVAL_SECONDS=1
 
-# est and dps are configured as urls, the iothub as a bare host
-function endpoint_host()
+# est and dps are configured as urls, the iothub as a bare host. an ipv6 literal
+# is unwrapped because getent takes the bare address
+function url_host()
 {
-    local key value
+    local value="${1#*://}"
 
-    for key in cert_issuance.est.urls.default \
-               provisioning.global_endpoint \
-               provisioning.iothub_hostname; do
-        value=$(toml get "${AZIOT_CONFIG}" "${key}" 2>/dev/null | tr -d '"')
-        [ -n "${value}" ] || continue
-        value="${value#*://}"
-        value="${value%%/*}"
-        echo "${value%%:*}"
-        return 0
-    done
+    value="${value%%/*}"
+    value="${value##*@}"
 
-    return 1
+    case "${value}" in
+        \[*) value="${value#\[}"
+             echo "${value%%\]*}"
+             ;;
+        *)   echo "${value%%:*}"
+             ;;
+    esac
 }
 
-host=$(endpoint_host) || exit 0
+# which endpoint identityd needs first depends on the provisioning method, and
+# they are not always the same domain, so every configured one is probed
+declare -A seen=()
+pending=()
 
-# a failing lookup blocks for the resolver timeout, so cap on wall clock and
-# not on attempts
-deadline=$(( SECONDS + TIMEOUT_SECONDS ))
-while true; do
-    getent ahosts "${host}" > /dev/null && exit 0
-    [ "${SECONDS}" -lt "${deadline}" ] || break
-    sleep ${POLL_INTERVAL_SECONDS}
+for key in cert_issuance.est.urls.default \
+           provisioning.global_endpoint \
+           provisioning.iothub_hostname; do
+    # toml prints nothing for an absent key
+    value=$(toml get -r "${AZIOT_CONFIG}" "${key}")
+    [[ -n "${value}" ]] || continue
+
+    host=$(url_host "${value}")
+    [[ -n "${host}" && -z "${seen[${host}]}" ]] || continue
+    seen["${host}"]=1
+    pending+=("${host}")
 done
 
-echo "${host} does not resolve after ${TIMEOUT_SECONDS}s, starting anyway" >&2
+[[ ${#pending[@]} -gt 0 ]] || exit 0
+
+# a failing lookup blocks for the resolver timeout, so cap the single lookup and
+# the whole wait on wall clock and not on attempts. every host still pending
+# gets a try per pass, so one that never resolves cannot eat the deadline of the
+# others
+deadline=$(( SECONDS + TIMEOUT_SECONDS ))
+
+while [[ ${#pending[@]} -gt 0 && "${SECONDS}" -lt "${deadline}" ]]; do
+    remaining=()
+
+    for host in "${pending[@]}"; do
+        timeout "${LOOKUP_TIMEOUT_SECONDS}" getent ahosts "${host}" > /dev/null \
+            || remaining+=("${host}")
+    done
+
+    pending=("${remaining[@]}")
+    [[ ${#pending[@]} -gt 0 ]] || break
+    sleep "${POLL_INTERVAL_SECONDS}"
+done
+
+[[ ${#pending[@]} -eq 0 ]] \
+    || echo "${pending[*]} does not resolve within ${TIMEOUT_SECONDS}s, starting anyway" >&2
+
 exit 0


### PR DESCRIPTION
## Summary

`aziot-identityd.service` gets a second `ExecStartPre` which waits until every endpoint host configured in `/etc/aziot/config.toml` resolves - `cert_issuance.est.urls.default`, `provisioning.global_endpoint` and `provisioning.iothub_hostname`. A single lookup is capped at 5 s and the whole wait at 30 s. No endpoint configured means no wait, and on timeout the daemon starts anyway.

## Reason

identityd enrolls the `device-id` cert via EST and reaches out to DPS right at start. When the resolver cannot answer it gets `EAI_AGAIN`, exits 1 and is restarted; the second attempt succeeds. This hits the first boot after flashing or a factory reset - the state every CI DUT boots in. The failed start also fails the ADU agent health check and logs `[ERR!]` lines that are not in the smoke-test syslog whitelist, while neither the crash-loop check nor `systemctl is-system-running` can see it: a unit that failed once and recovered is `active` with `NRestarts=1`.

Seen twice on the rpi4 nightly, last in `test-image-job` 541. The lookup blocks for its full resolver timeout before it fails: `aziot-certd` starts at 18:09:14 and reports `Temporary failure in name resolution` at 18:09:34, identityd exits, and the restart at 18:09:40 succeeds. The rest of the network worked for the whole of those 20 s - the test runner opened dozens of ssh connections to the DUT between 18:09:15 and 18:09:34, and timesyncd had reached the lab time server at 18:09:08, before the window. So the queries were sent and stayed unanswered, which is a different thing from resolved having no server at all - that case fails immediately instead of blocking. Why the resolver was silent for those 20 s is not established; it is the lab resolver handed out by DHCP, and it answers in a few milliseconds when warm.

The unit already waits for `network-online.target`, and that target only says a link is configured. DHCP hands out the address of a DNS server, not a DNS server that answers, and no ordering can express "a name resolves" - which is why the wait has to attempt a lookup. It also means the gate does not depend on which cause it was: resolver not warm, resolved not ready or an upstream that is slow all end in the same wait.

Which endpoint identityd needs first depends on the provisioning method, and they are not the same domain, so every configured host is probed and each one still pending gets one try per pass - a host that never resolves must not starve the others. The single lookup is capped as well, because a failing lookup blocks for the resolver timeout: the unit sets no `TimeoutStartSec`, so its ceiling is the 90 s default, and running into it would produce the very failed start this gate exists to prevent.

The gate delays the start and never skips it. A condition-skipped activation would consume `aziot-identityd.socket`'s trigger limit of 20 within 2 s, and a failed socket is never activated again on its own (#680).
