### PR TITLE
fix(omnect-base-files): select the device id fallback on an empty toml result

### DIFF
--- a/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
+++ b/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
@@ -3,7 +3,7 @@
 # toml exits non-zero with no output for an absent key, so an empty result is
 # what selects the fallback
 device_id=$(toml get /etc/aziot/config.toml provisioning.attestation.registration_id 2>/dev/null)
-[ -n "${device_id}" ] && [ "${device_id}" != "null" ] \
+[ -n "${device_id}" ] \
     || device_id=$(toml get /etc/aziot/config.toml provisioning.device_id 2>/dev/null)
 
 echo "${device_id}" | tr -d '"'

--- a/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
+++ b/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-device_id=$(toml get /etc/aziot/config.toml provisioning.attestation.registration_id)
-[[ "${device_id}" == "null" ]] && device_id=$(toml get /etc/aziot/config.toml provisioning.device_id)
+# toml exits non-zero with no output for an absent key, so an empty result is
+# what selects the fallback
+device_id=$(toml get /etc/aziot/config.toml provisioning.attestation.registration_id 2>/dev/null)
+[ -n "${device_id}" ] && [ "${device_id}" != "null" ] \
+    || device_id=$(toml get /etc/aziot/config.toml provisioning.device_id 2>/dev/null)
 
-echo ${device_id} | tr -d '"'
+echo "${device_id}" | tr -d '"'

--- a/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
+++ b/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# toml exits non-zero with no output for an absent key, so an empty result is
-# what selects the fallback
+# toml prints nothing for an absent key
 device_id=$(toml get /etc/aziot/config.toml provisioning.attestation.registration_id 2>/dev/null)
 [ -n "${device_id}" ] \
     || device_id=$(toml get /etc/aziot/config.toml provisioning.device_id 2>/dev/null)

--- a/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
+++ b/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
@@ -5,4 +5,8 @@ device_id=$(toml get -r /etc/aziot/config.toml provisioning.attestation.registra
 [[ -n "${device_id}" ]] \
     || device_id=$(toml get -r /etc/aziot/config.toml provisioning.device_id)
 
+# sshd logs nothing of its own when the principals list comes back empty
+[[ -n "${device_id}" ]] \
+    || logger -t omnect_get_deviceid "no device id in /etc/aziot/config.toml"
+
 echo "${device_id}"

--- a/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
+++ b/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
@@ -5,7 +5,8 @@ device_id=$(toml get -r /etc/aziot/config.toml provisioning.attestation.registra
 [[ -n "${device_id}" ]] \
     || device_id=$(toml get -r /etc/aziot/config.toml provisioning.device_id)
 
-# sshd logs nothing of its own when the principals list comes back empty
+# sshd runs this as AuthorizedPrincipalsCommand and reports only the failed
+# authentication, not the empty principals list, so put the reason in syslog
 [[ -n "${device_id}" ]] \
     || logger -t omnect_get_deviceid "no device id in /etc/aziot/config.toml"
 

--- a/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
+++ b/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 # toml prints nothing for an absent key
-device_id=$(toml get /etc/aziot/config.toml provisioning.attestation.registration_id 2>/dev/null)
-[ -n "${device_id}" ] \
-    || device_id=$(toml get /etc/aziot/config.toml provisioning.device_id 2>/dev/null)
+device_id=$(toml get -r /etc/aziot/config.toml provisioning.attestation.registration_id)
+[[ -n "${device_id}" ]] \
+    || device_id=$(toml get -r /etc/aziot/config.toml provisioning.device_id)
 
-echo "${device_id}" | tr -d '"'
+echo "${device_id}"

--- a/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
+++ b/recipes-omnect/omnect-base-files/omnect-base-files/usr/bin/omnect_get_deviceid.sh
@@ -5,8 +5,6 @@ device_id=$(toml get -r /etc/aziot/config.toml provisioning.attestation.registra
 [[ -n "${device_id}" ]] \
     || device_id=$(toml get -r /etc/aziot/config.toml provisioning.device_id)
 
-# sshd runs this as AuthorizedPrincipalsCommand and reports only the failed
-# authentication, not the empty principals list, so put the reason in syslog
 [[ -n "${device_id}" ]] \
     || logger -t omnect_get_deviceid "no device id in /etc/aziot/config.toml"
 


### PR DESCRIPTION
## Summary

`omnect_get_deviceid.sh` falls back to `provisioning.device_id` on an empty toml result instead of testing for the string `null`, lets `toml get -r` print the id unquoted, and logs when it ends up with no id at all.

## Reason

`toml` (toml-cli 0.2.3, pinned by `SRCREV`) exits non-zero and prints nothing for an absent key - it never prints `null`, so the fallback was dead code. A device provisioned through `provisioning.device_id` rather than DPS attestation therefore got an empty device id, and since the script is sshd's `AuthorizedPrincipalsCommand`, no principals at all.

The quotes the script stripped came from toml-cli's JSON output, not from the value itself, so `-r` removes the need for the `tr` process.

An empty result had no signal of its own. sshd takes the output as the principals list and logs nothing when it is empty, so a certificate login failed without a reason anywhere. The stderr of `toml` is not a reliable stand-in: it is silent for an absent key, and it only reaches the journal at all because sshd asks for the subprocess stderr to be discarded while its helper acts on the stdout flag instead - a one-word upstream fix would take it away. The script says so itself now, and the `2>/dev/null` that could only hide a missing or unparsable config is gone as well.
