### PR TITLE
fix(kas): patch bitbake gitsm premirror-only submodule fetch

### DIFF
--- a/kas/distro/oe.yaml
+++ b/kas/distro/oe.yaml
@@ -10,6 +10,10 @@ repos:
     commit: "acfe02fa38b5da9e6a36c6cedcf91d4fcbefbfbd"
     layers:
       .: 0
+    patches:
+      p001:
+        repo: "meta-omnect"
+        path: "kas/patches/bitbake_gitsm_premirroronly_submodule_fix.patch"
   ext/_openembedded-core: #_ prefixed because of layer order with same prio e.g. meta-openembedded
     url: "https://git.openembedded.org/openembedded-core"
     branch: "wrynose"

--- a/kas/patches/bitbake_gitsm_premirroronly_submodule_fix.patch
+++ b/kas/patches/bitbake_gitsm_premirroronly_submodule_fix.patch
@@ -1,0 +1,27 @@
+diff --git a/lib/bb/fetch2/gitsm.py b/lib/bb/fetch2/gitsm.py
+index 5869e1b99..e7fa21847 100644
+--- a/lib/bb/fetch2/gitsm.py
++++ b/lib/bb/fetch2/gitsm.py
+@@ -195,7 +195,21 @@ class GitSM(Git):
+             #url += ";nocheckout=1"
+ 
+             try:
+-                newfetch = Fetch([url], d, cache=False)
++                submodule_d = d
++                # When BB_FETCH_PREMIRRORONLY is enabled, try_mirror_url() hands
++                # gitsm a datastore copy with BB_NO_NETWORK="1" (bitbake commit
++                # 1b1321f2b) so the top-level git fetcher can no longer reach
++                # upstream after downloading the mirror tarball. That flag also
++                # disables the *premirror* phase of the nested submodule fetch
++                # below, so the submodule can no longer be pulled from the
++                # premirror either. Clear it for the submodule fetch: the nested
++                # Fetch re-applies BB_NO_NETWORK itself after its own premirror
++                # stage when premirroronly is set, so upstream access stays
++                # blocked while premirror access is restored.
++                if bb.utils.to_boolean(d.getVar("BB_FETCH_PREMIRRORONLY")):
++                    submodule_d = d.createCopy()
++                    submodule_d.delVar("BB_NO_NETWORK")
++                newfetch = Fetch([url], submodule_d, cache=False)
+                 newfetch.download()
+             except Exception as e:
+                 logger.error('gitsm: submodule download failed: %s %s' % (type(e).__name__, str(e)))


### PR DESCRIPTION
## Problem

Mirror-only builds (`own_mirror_only.yaml`, `BB_FETCH_PREMIRRORONLY=1`) fail in
gitsm recipes — first `p11-kit-native do_fetch` — with:

```
NetworkAccess: Network access disabled through BB_NO_NETWORK
(or set indirectly due to use of BB_FETCH_PREMIRRORONLY) but access requested ...
```

## Cause

bitbake commit [`1b1321f2b`](https://git.openembedded.org/bitbake/commit/?id=1b1321f2b)
(yocto-5.3/whinlatter, pulled in by the wrynose upgrade) makes `try_mirror_url()`
hand the real fetcher a datastore copy with `BB_NO_NETWORK="1"` when
`BB_FETCH_PREMIRRORONLY` is set. gitsm processes its submodules via a nested
`bb.fetch2.Fetch` on that copy, so the submodule's *premirror* download runs with
network disabled and is rejected — even though the tarball is on the mirror. The
top-level tarball is unaffected (its premirror fetch happens before
`BB_NO_NETWORK` is forced). Still unfixed on bitbake master.

## Fix

Apply a self-contained bitbake patch
(`kas/patches/bitbake_gitsm_premirroronly_submodule_fix.patch`, wired into
`kas/distro/oe.yaml` under `ext/bitbake`) to gitsm's `download_submodule`: when
`BB_FETCH_PREMIRRORONLY` is set, give the nested submodule fetch a datastore copy
with `BB_NO_NETWORK` cleared. That fetch's own premirror-then-block logic still
prevents upstream access, so the top-level guard from `1b1321f2b` is preserved.

Patching bitbake keeps mirror-only builds self-contained: customers can rebuild
from the published sources without any extra prefetch step on their side.
