### PR TITLE
systemd: build without TPM2 support

### DIFF
--- a/recipes-core/systemd/systemd_%.bbappend
+++ b/recipes-core/systemd/systemd_%.bbappend
@@ -8,6 +8,11 @@ SRC_URI += "\
 
 RDEPENDS:${PN} += "bash"
 
+# systemd's TPM2 features are unused (no encrypted volumes, no sealed
+# credentials) and they pull in systemd-tpm2-setup, which fails once the TPM's
+# dictionary attack counter is exhausted and then leaves the system degraded.
+PACKAGECONFIG:remove = "tpm2"
+
 # enable bash-completion
 bashcompletiondir = "${datadir}/bash-completion/completions"
 


### PR DESCRIPTION
**Summary**

Build systemd without its TPM2 feature set (`-Dtpm2=disabled`). That drops `systemd-tpm2-setup.service` and `-early`, the NvPCR initialization and the `systemd-pcr*` units.

**Reason**

`systemd-tpm2-setup` seals an NvPCR anchor secret into the TPM on every boot. The seal is dictionary attack protected, so it fails while the TPM's failed-tries counter sits at `maxTries`: the unit fails, the system state turns `degraded`, and an update under validation is rolled back although the update is fine. The counter climbs on its own, because every reset without an orderly `TPM2_Shutdown` adds one and nothing ever resets it.

Nothing uses the feature: there are no encrypted volumes, no TPM sealed credentials, and no reference to NvPCRs in this layer. The TPM stays available to the identity service, which links `libtss2` directly, and to `tpm2-tools`. Images built before the feature was turned on report `-TPM2` and ship no such unit.
