### PR TITLE
chore: drop unused image files and the perl build dependency, restrict /dev/crypto

### DIFF
--- a/conf/distro/include/omnect-os-distro.conf
+++ b/conf/distro/include/omnect-os-distro.conf
@@ -163,6 +163,8 @@ PACKAGECONFIG:pn-opkg-utils = "update-alternatives"
 # get rid of perl as runtime dependency in release image
 PACKAGES:remove:pn-nss = "nss-smime"
 PACKAGES:remove:pn-openssl = "openssl-misc"
+# nspr-dev is the only recipe pulling target perl into the build
+RDEPENDS:nspr-dev:remove = "perl"
 PACKAGECONFIG:remove:pn-apparmor = "perl"
 DEPENDS:remove:pn-apparmor = "perl"
 # apparmor inherits cpan, which exports PERLCONFIGTARGET=yes and makes the native

--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -23,6 +23,9 @@ IMAGE_BOOT_FILES:remove:pn-omnect-os-image = " \
 
 IMAGE_INSTALL:append:pn-omnect-os-image = " kernel-devicetree"
 
+# the imx BSP installs the cryptodev module; restrict its device node to root
+IMAGE_INSTALL:append:pn-omnect-os-image = " cryptodev-udev"
+
 # initramfs type
 OMNECT_INITRAMFS_FSTYPE = "cpio.gz.u-boot"
 

--- a/recipes-connectivity/openssl/openssl_%.bbappend
+++ b/recipes-connectivity/openssl/openssl_%.bbappend
@@ -1,0 +1,6 @@
+# openssl-misc is dropped from PACKAGES, which leaves its perl scripts in the
+# main package - remove the files as well.
+do_install:append:class-target() {
+    rm -f ${D}${bindir}/c_rehash
+    rm -rf ${D}${libdir}/ssl-3/misc
+}

--- a/recipes-omnect/cryptodev-udev/cryptodev-udev.bb
+++ b/recipes-omnect/cryptodev-udev/cryptodev-udev.bb
@@ -1,0 +1,20 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/${PN}:"
+
+# file-only recipe: sources land in ${UNPACKDIR} now which is by default
+# ${WORKDIR}/sources
+S = "${UNPACKDIR}"
+
+LICENSE = "MIT | Apache-2.0"
+LIC_FILES_CHKSUM = " \
+	file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10 \
+	file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302 \
+"
+
+SRC_URI = "\
+    file://10-cryptodev.rules \
+"
+
+do_install() {
+	install -d ${D}${sysconfdir}/udev/rules.d
+	install -m 0644 ${UNPACKDIR}/10-cryptodev.rules ${D}${sysconfdir}/udev/rules.d/
+}

--- a/recipes-omnect/cryptodev-udev/cryptodev-udev/10-cryptodev.rules
+++ b/recipes-omnect/cryptodev-udev/cryptodev-udev/10-cryptodev.rules
@@ -1,0 +1,3 @@
+# the driver creates /dev/crypto world read/write; nothing in the image uses it.
+# low number so a customer rule can override the mode.
+KERNEL=="crypto", SUBSYSTEM=="misc", MODE="0600"

--- a/recipes-support/nss/nss_%.bbappend
+++ b/recipes-support/nss/nss_%.bbappend
@@ -1,0 +1,12 @@
+# nss packages the whole bindir, but the image uses none of the tools. Keep
+# shlibsign, which the postinst needs if it runs on first boot, and move the rest
+# into a package that is not installed.
+PACKAGES:append:class-target = " ${PN}-tools"
+
+FILES:${PN}:class-target = " \
+    ${sysconfdir} \
+    ${bindir}/shlibsign \
+    ${libdir}/lib*.chk \
+    ${libdir}/lib*.so \
+"
+FILES:${PN}-tools = "${bindir}"

--- a/recipes-support/nss/nss_%.bbappend
+++ b/recipes-support/nss/nss_%.bbappend
@@ -1,6 +1,5 @@
 # nss packages the whole bindir, but the image uses none of the tools. Keep
-# shlibsign, which the postinst needs if it runs on first boot, and move the rest
-# into a package that is not installed.
+# shlibsign, which the postinst needs if it runs on first boot.
 PACKAGES:append:class-target = " ${PN}-tools"
 
 FILES:${PN}:class-target = " \
@@ -9,4 +8,6 @@ FILES:${PN}:class-target = " \
     ${libdir}/lib*.chk \
     ${libdir}/lib*.so \
 "
+# PACKAGES order decides who claims a file first: nss takes shlibsign, nss-tools
+# the rest of bindir. No file ends up in both.
 FILES:${PN}-tools = "${bindir}"


### PR DESCRIPTION
## Summary

- **openssl** bbappend: delete `c_rehash` and `${libdir}/ssl-3/misc`
- **nss** bbappend: restrict `FILES:${PN}` to the libraries, the config and `shlibsign`, and move the rest of `${bindir}` into a new `nss-tools` package that no image installs
- **omnect-os-distro.conf**: `RDEPENDS:nspr-dev:remove = "perl"`
- **cryptodev-udev**: new file-only recipe shipping `10-cryptodev.rules`, which gives `/dev/crypto` mode `0600`; installed on tauril2 through the machine include. The module itself stays in the image.

## Reason

`omnect-os-distro.conf` already drops `openssl-misc` and `nss-smime` from `PACKAGES` to keep perl out of the image, but `PACKAGES:remove` only removes the package - the files move into the respective main package and still ship, as perl scripts in an image without a perl interpreter.

nss is the bigger case: the recipe has `FILES:${PN} = "... ${bindir} ..."`, so **49 tools** ship (`certutil`, `pk12util`, `selfserv`, `tstclnt`, `ssltap`, `signtool`, the test binaries, ...) although nothing in the image references any of them - networkmanager pulls nss in for the libraries only. Restricting the package and collecting the tools in `nss-tools` keeps them buildable for a debug image and takes them out of the release image, including `smime`, so no single-file removals are needed there. `shlibsign` stays in the main package because the nss postinst calls it, and that postinst can end up running on first boot. openssl keeps the file removal: upstream splits those two paths into `openssl-misc` and the main package claims them only because the distro drops that package.

perl itself shows up in the image SBOM although no perl file is in the image: the SBOM is written per built recipe, and the only recipe pulling target perl into the build is nspr (`RDEPENDS:${PN}-dev += "perl"`, nspr comes in via `networkmanager -> nss -> nspr`). Dev packages are never installed, so dropping that dependency changes nothing in the image while taking perl out of the build and out of the SBOM - four high/critical findings less to moderate per release.

On tauril2 the imx BSP installs the cryptodev module, it is loaded at boot, and the driver creates `/dev/crypto` world read/write, while upstream has no fix for CVE-2026-28529 (use-after-free in `get_userbuf()`, local privilege escalation). The module stays available for applications; the udev rule takes away the world read/write default, and its low number lets a customer rule override the mode.

No other BSP ships cryptodev, and no script, unit or binary in the 6.0.2 images references the removed files or `/dev/crypto`.
