### PR TITLE
fix(tauri): use the qemu version from oecore

### DIFF
--- a/conf/machine/include/phytec-imx8mm.inc
+++ b/conf/machine/include/phytec-imx8mm.inc
@@ -65,6 +65,16 @@ BBMASK:append = " \
     meta-imx/meta-imx-bsp/recipes-connectivity/openssl/openssl_3.2.%.bbappend \
 "
 
+# don't let meta-imx-bsp's qemu fork override the one from oecore: it is meant
+# for mx95 only and its ui/sdl2.c assigns qemu_egl_display outside of any
+# CONFIG_OPENGL guard, so nativesdk-qemu fails to compile for meta-toolchain.
+BBMASK:append = " meta-imx/meta-imx-bsp/recipes-devtools/qemu/"
+
+# meta-phytec pins QEMUVERSION to "8.2%", which no longer resolves and thereby
+# defeats meta-imx's pin to oecore's qemu; with the fork masked above there is
+# only one qemu left to choose, so drop the dangling preferred-version pins.
+QEMUVERSION = ""
+
 # mask phytec's Cortex-M demo bbappend: its base recipe lives in the dropped
 # meta-imx-sdk, so it would dangle; we don't want the demos anyway.
 BBMASK:append = " meta-phytec/dynamic-layers/fsl-bsp-release/recipes-fsl/mcore-demos/"


### PR DESCRIPTION
meta-imx-bsp ships an i.MX qemu fork it pins to mx95 only, while all other i.MX machines get oecore's qemu via `QEMUVERSION ??= "10.2.0"`. meta-phytec overrides QEMUVERSION with a stale "8.2%", which resolves to nothing and thus defeats that pin, so bitbake falls back to the highest version available - the fork. Its ui/sdl2.c assigns qemu_egl_display outside of any CONFIG_OPENGL guard, which breaks nativesdk-qemu, since we build qemu with sdl but without opengl:

  ui/sdl2.c: In function 'sdl2_window_create':
  ui/sdl2.c:128:5: error: 'qemu_egl_display' undeclared (first use in this function)

Mask the fork and drop the dangling preferred-version pins.