### PR TITLE
fix(nspr): drop runtests.pl so nspr-dev does not need perl

### DIFF
--- a/recipes-support/nspr/nspr_%.bbappend
+++ b/recipes-support/nspr/nspr_%.bbappend
@@ -1,0 +1,6 @@
+# runtests.pl in nspr-dev is the only file that makes the package need perl, and
+# the tests are never run on a device. The recipe drops compile-et.pl from bindir
+# for the same reason.
+do_install:append:class-target() {
+    rm -f ${D}${libdir}/nspr/tests/runtests.pl
+}


### PR DESCRIPTION
## Summary

New `nspr` bbappend that deletes `${libdir}/nspr/tests/runtests.pl` for target builds.

## Reason

#690 broke the build. `RDEPENDS:nspr-dev:remove = "perl"` takes perl out of the build graph, but `nspr-dev` still ships a perl script, so the `file-rdeps` QA check fails:

```
ERROR: nspr-4.38.2-r0 do_package_qa: QA Issue: /usr/lib/nspr/tests/runtests.pl contained in package nspr-dev requires /usr/bin/perl, but no providers found in RDEPENDS:nspr-dev? [file-rdeps]
ERROR: nspr-4.38.2-r0 do_package_qa: Fatal QA errors were found, failing task.
```

The recipe installs that script itself (`install -m 0755 ${S}/pr/tests/runtests.pl ${D}${libdir}/nspr/tests`) and packages it through the `${libdir}/nspr/tests/*` glob in `FILES:${PN}-dev`. It only drives the nspr test binaries, which no image runs, and the recipe already deletes `compile-et.pl` from `${bindir}` for exactly the same reason. Deleting this one file is therefore the honest fix; the alternative, `INSANE_SKIP:nspr-dev += "file-rdeps"`, would only silence a check that is telling the truth.

This is a build-machine-independent failure: it is `nspr:do_package_qa`, so it hits every build whose graph contains nspr. From the same trigger (wrynose/dev/gateway-devel, build 6):

- `rpi4-omnect-lab` failed at 13:44 - the first build to reach that task
- `genericx86-64` hit the identical error while still running
- `dehndetect` passed: nspr does not appear once in its build log, so that image does not pull it in
- `tauril2` build 6 errored for an unrelated reason (no nspr in its log); 6.1 is running
- `rpi4` was still before that task at the time of writing

If CI still fails on nspr after this, the fallback is to revert the `RDEPENDS:nspr-dev:remove` line from #690 and accept perl in the build and the SBOM again.
